### PR TITLE
Add kinetic globe spin and landing highlights

### DIFF
--- a/Globe.qml
+++ b/Globe.qml
@@ -16,6 +16,13 @@ Item {
   property real maximumScale: 24
   property real longitudeSensitivity: 0.22
   property real latitudeSensitivity: 0.18
+  property bool kineticRotationEnabled: true
+
+  readonly property real kineticLaunchSpeed: 120
+  readonly property real kineticMaximumSpeed: 2400
+  readonly property real kineticDeceleration: 1800
+  readonly property real kineticMaximumFrameTime: 0.1
+  readonly property real kineticMaximumSampleAge: 100
 
   property color backgroundColor: "#090a0c"
   property color sphereColor: "#11151a"
@@ -30,6 +37,13 @@ Item {
   property var hoveredStation: null
   property real hoverX: 0
   property real hoverY: 0
+  property var highlightedStation: null
+  property real highlightX: 0
+  property real highlightY: 0
+  property real kineticVelocityX: 0
+  property real kineticVelocityY: 0
+  property int kineticLaunchGeneration: 0
+  property bool suppressNextTap: false
   property var preparedCountries: []
   property var preparedGrid: []
   property var preparedStations: []
@@ -40,7 +54,7 @@ Item {
   signal pointerMoved()
 
   Accessible.name: "Interactive world radio globe"
-  Accessible.description: "Drag to rotate, use the mouse wheel to zoom, and select a station signal or country"
+  Accessible.description: "Drag or flick to rotate, use the mouse wheel to zoom, and select a station signal or country"
   Accessible.role: Accessible.Pane
 
   function radius() {
@@ -51,11 +65,90 @@ Item {
     return Qt.rgba(color.r, color.g, color.b, alpha)
   }
 
+  function clearLandingHighlight() {
+    highlightedStation = null
+    highlightX = 0
+    highlightY = 0
+  }
+
+  function stopKineticRotation(clearLanding) {
+    kineticLaunchGeneration += 1
+    kineticAnimation.running = false
+    kineticVelocityX = 0
+    kineticVelocityY = 0
+    if (clearLanding === true) clearLandingHighlight()
+  }
+
+  function startKineticRotation(velocityX, velocityY) {
+    if (!kineticRotationEnabled) return false
+    var launch = RadioModel.kineticLaunchVelocity(
+      velocityX, velocityY, kineticLaunchSpeed, kineticMaximumSpeed)
+    if (!launch.active) return false
+
+    kineticLaunchGeneration += 1
+    clearLandingHighlight()
+    hoveredStation = null
+    kineticVelocityX = launch.x
+    kineticVelocityY = launch.y
+    kineticAnimation.running = true
+    return true
+  }
+
+  function finishKineticRotation() {
+    kineticAnimation.running = false
+    kineticVelocityX = 0
+    kineticVelocityY = 0
+    hoveredStation = null
+    var excludedUuid = selectedStation ? selectedStation.uuid : ""
+    highlightedStation = RadioModel.nearestVisibleStation(
+      stations, centreLatitude, centreLongitude, excludedUuid,
+      width, height, globeScale)
+  }
+
+  function rotateByPointerDelta(deltaX, deltaY) {
+    centreLongitude = RadioModel.wrapLongitude(
+      centreLongitude - deltaX * longitudeSensitivity / globeScale)
+    centreLatitude = RadioModel.clamp(
+      centreLatitude + deltaY * latitudeSensitivity / globeScale, -78, 78)
+  }
+
+  function stationByUuid(uuid) {
+    var wanted = String(uuid || "")
+    var rows = Array.isArray(stations) ? stations : []
+    for (var i = 0; i < rows.length; i++)
+      if (String(rows[i] && rows[i].uuid || "") === wanted) return rows[i]
+    return null
+  }
+
+  function refreshLandingHighlight() {
+    if (!highlightedStation) return
+    var replacement = stationByUuid(highlightedStation.uuid)
+    if (!replacement) {
+      clearLandingHighlight()
+      return
+    }
+    highlightedStation = replacement
+    updateHighlightPosition()
+  }
+
+  function updateHighlightPosition() {
+    if (!highlightedStation) return
+    var position = RadioModel.stationPosition(
+      highlightedStation, width, height, globeScale, centreLatitude, centreLongitude)
+    if (!position) {
+      clearLandingHighlight()
+      return
+    }
+    highlightX = position.x
+    highlightY = position.y
+  }
+
   function focusCoordinate(latitude, longitude) {
     var nextLatitude = Number(latitude)
     var nextLongitude = Number(longitude)
     if (!isFinite(nextLatitude) || !isFinite(nextLongitude)) return
 
+    stopKineticRotation(true)
     centreLatitude = RadioModel.clamp(nextLatitude, -78, 78)
     centreLongitude = RadioModel.wrapLongitude(nextLongitude)
   }
@@ -312,17 +405,20 @@ Item {
       row.depth = depth
 
       var selected = selectedStation && row.station.uuid === selectedStation.uuid
-      var markerRadius = selected ? 4.2 : 1.7 + depth * 1.25
+      var highlighted = highlightedStation
+        && row.station.uuid === highlightedStation.uuid && !selected
+      var markerRadius = selected ? 4.2 : (highlighted ? 3.7 : 1.7 + depth * 1.25)
       ctx.beginPath()
       ctx.arc(row.screenX, row.screenY, markerRadius, 0, Math.PI * 2)
-      ctx.fillStyle = selected ? accentColor : withAlpha(signalColor, 0.42 + depth * 0.48)
+      ctx.fillStyle = selected || highlighted
+        ? accentColor : withAlpha(signalColor, 0.42 + depth * 0.48)
       ctx.fill()
 
-      if (selected) {
+      if (selected || highlighted) {
         ctx.beginPath()
-        ctx.arc(row.screenX, row.screenY, 8.5, 0, Math.PI * 2)
-        ctx.strokeStyle = withAlpha(accentColor, 0.72)
-        ctx.lineWidth = 1.2
+        ctx.arc(row.screenX, row.screenY, selected ? 8.5 : 7.5, 0, Math.PI * 2)
+        ctx.strokeStyle = withAlpha(accentColor, selected ? 0.72 : 0.92)
+        ctx.lineWidth = selected ? 1.2 : 1.4
         ctx.stroke()
       }
     }
@@ -382,6 +478,7 @@ Item {
   }
 
   function activateAt(x, y) {
+    clearLandingHighlight()
     var station = stationUnderPointer(x, y)
     if (station) {
       stationActivated(station)
@@ -407,15 +504,44 @@ Item {
   }
   onStationsChanged: {
     preparedStations = prepareStationGeometry()
+    refreshLandingHighlight()
     globeCanvas.requestPaint()
   }
-  onSelectedStationChanged: globeCanvas.requestPaint()
+  onSelectedStationChanged: {
+    clearLandingHighlight()
+    globeCanvas.requestPaint()
+  }
   onActiveCountryCodeChanged: globeCanvas.requestPaint()
-  onCentreLatitudeChanged: globeCanvas.requestPaint()
-  onCentreLongitudeChanged: globeCanvas.requestPaint()
-  onGlobeScaleChanged: globeCanvas.requestPaint()
-  onWidthChanged: globeCanvas.requestPaint()
-  onHeightChanged: globeCanvas.requestPaint()
+  onCentreLatitudeChanged: {
+    updateHighlightPosition()
+    globeCanvas.requestPaint()
+  }
+  onCentreLongitudeChanged: {
+    updateHighlightPosition()
+    globeCanvas.requestPaint()
+  }
+  onGlobeScaleChanged: {
+    updateHighlightPosition()
+    globeCanvas.requestPaint()
+  }
+  onWidthChanged: {
+    updateHighlightPosition()
+    globeCanvas.requestPaint()
+  }
+  onHeightChanged: {
+    updateHighlightPosition()
+    globeCanvas.requestPaint()
+  }
+  onHighlightedStationChanged: {
+    updateHighlightPosition()
+    globeCanvas.requestPaint()
+  }
+  onKineticRotationEnabledChanged: {
+    if (!kineticRotationEnabled) stopKineticRotation(true)
+  }
+  onVisibleChanged: {
+    if (!visible) stopKineticRotation(true)
+  }
 
   Canvas {
     id: globeCanvas
@@ -434,91 +560,258 @@ Item {
     globeCanvas.requestPaint()
   }
 
-  MouseArea {
-    id: pointer
-    anchors.fill: parent
-    hoverEnabled: true
-    acceptedButtons: Qt.LeftButton
-    cursorShape: pressed
+  HoverHandler {
+    id: hoverHandler
+    cursorShape: dragHandler.active || tapHandler.pressed
       ? Qt.ClosedHandCursor
       : (root.hoveredStation ? Qt.PointingHandCursor : Qt.OpenHandCursor)
 
-    property real lastX: 0
-    property real lastY: 0
-    property real totalMovement: 0
+    onPointChanged: {
+      root.hoverX = point.position.x
+      root.hoverY = point.position.y
+      root.pointerMoved()
+      root.hoveredStation = kineticAnimation.running || dragHandler.active
+        ? null : root.stationUnderPointer(point.position.x, point.position.y)
+    }
 
-    onPressed: function(mouse) {
+    onHoveredChanged: {
+      if (!hovered) root.hoveredStation = null
+    }
+  }
+
+  TapHandler {
+    id: tapHandler
+    acceptedButtons: Qt.LeftButton
+    gesturePolicy: TapHandler.DragThreshold
+
+    onPressedChanged: {
+      if (!pressed) return
       root.interactionStarted()
-      lastX = mouse.x
-      lastY = mouse.y
-      totalMovement = 0
+      var caughtKineticRotation = kineticAnimation.running
+      root.stopKineticRotation(true)
+      root.suppressNextTap = caughtKineticRotation
       root.hoveredStation = null
     }
 
-    onPositionChanged: function(mouse) {
-      root.hoverX = mouse.x
-      root.hoverY = mouse.y
-      if (!(pressedButtons & Qt.LeftButton)) {
-        root.pointerMoved()
-        root.hoveredStation = root.stationUnderPointer(mouse.x, mouse.y)
+    onTapped: function(eventPoint) {
+      if (root.suppressNextTap) {
+        root.suppressNextTap = false
         return
       }
-
-      var deltaX = mouse.x - lastX
-      var deltaY = mouse.y - lastY
-      var longitudeDelta = -deltaX * root.longitudeSensitivity / root.globeScale
-      var latitudeDelta = deltaY * root.latitudeSensitivity / root.globeScale
-
-      root.centreLongitude = RadioModel.wrapLongitude(root.centreLongitude + longitudeDelta)
-      root.centreLatitude = RadioModel.clamp(root.centreLatitude + latitudeDelta, -78, 78)
-      totalMovement += Math.abs(deltaX) + Math.abs(deltaY)
-      lastX = mouse.x
-      lastY = mouse.y
+      root.activateAt(eventPoint.position.x, eventPoint.position.y)
+      root.hoveredStation = hoverHandler.hovered
+        ? root.stationUnderPointer(eventPoint.position.x, eventPoint.position.y) : null
     }
 
-    onReleased: function(mouse) {
-      if (totalMovement < 7) {
-        root.activateAt(mouse.x, mouse.y)
-        root.hoveredStation = root.stationUnderPointer(mouse.x, mouse.y)
+    onCanceled: root.suppressNextTap = false
+  }
+
+  DragHandler {
+    id: dragHandler
+    target: null
+    acceptedButtons: Qt.LeftButton
+
+    property bool wasActive: false
+    property bool launchCanceled: false
+    property bool launchPending: false
+    property int pendingLaunchGeneration: 0
+    property real pendingVelocityX: 0
+    property real pendingVelocityY: 0
+    property real recentVelocityX: 0
+    property real recentVelocityY: 0
+    property real recentVelocityAt: 0
+    property real samplePositionX: 0
+    property real samplePositionY: 0
+    property real sampleStartedAt: 0
+
+    function resetMotionSample() {
+      recentVelocityX = 0
+      recentVelocityY = 0
+      recentVelocityAt = 0
+      samplePositionX = centroid.position.x
+      samplePositionY = centroid.position.y
+      sampleStartedAt = Date.now()
+    }
+
+    function recordMotionSample() {
+      // Qt's filtered mouse velocity can fall below the launch floor before
+      // release. Keep a short, capped-by-launch recent sample for human-speed
+      // flicks; the coast itself still uses frame-time-independent physics.
+      var now = Date.now()
+      var elapsedMilliseconds = now - sampleStartedAt
+      if (elapsedMilliseconds <= 0) return
+
+      var deltaX = centroid.position.x - samplePositionX
+      var deltaY = centroid.position.y - samplePositionY
+      samplePositionX = centroid.position.x
+      samplePositionY = centroid.position.y
+      sampleStartedAt = now
+      if (elapsedMilliseconds > 250) return
+
+      var sampledVelocityX = deltaX * 1000 / elapsedMilliseconds
+      var sampledVelocityY = deltaY * 1000 / elapsedMilliseconds
+      if (!isFinite(sampledVelocityX) || !isFinite(sampledVelocityY)) return
+      if (recentVelocityAt > 0) {
+        recentVelocityX = recentVelocityX * 0.25 + sampledVelocityX * 0.75
+        recentVelocityY = recentVelocityY * 0.25 + sampledVelocityY * 0.75
+      } else {
+        recentVelocityX = sampledVelocityX
+        recentVelocityY = sampledVelocityY
       }
+      recentVelocityAt = now
     }
 
-    onExited: if (!(pressedButtons & Qt.LeftButton)) root.hoveredStation = null
+    onActiveChanged: {
+      if (active) {
+        root.stopKineticRotation(true)
+        wasActive = true
+        launchCanceled = false
+        launchPending = false
+        root.suppressNextTap = false
+        root.interactionStarted()
+        root.hoveredStation = null
+        resetMotionSample()
+        return
+      }
+      if (!wasActive) return
 
-    onWheel: function(wheel) {
+      wasActive = false
+      var releaseVelocity = RadioModel.kineticReleaseVelocity(
+        centroid.velocity.x, centroid.velocity.y,
+        recentVelocityX, recentVelocityY,
+        recentVelocityAt > 0 ? Date.now() - recentVelocityAt : Infinity,
+        root.kineticMaximumSampleAge)
+      pendingVelocityX = releaseVelocity.x
+      pendingVelocityY = releaseVelocity.y
+      pendingLaunchGeneration = root.kineticLaunchGeneration
+      launchPending = !launchCanceled
+      Qt.callLater(function() {
+        if (!dragHandler.launchPending || dragHandler.launchCanceled) return
+        if (dragHandler.pendingLaunchGeneration !== root.kineticLaunchGeneration) {
+          dragHandler.launchPending = false
+          return
+        }
+        dragHandler.launchPending = false
+        root.startKineticRotation(
+          dragHandler.pendingVelocityX, dragHandler.pendingVelocityY)
+      })
+    }
+
+    onTranslationChanged: function(delta) {
+      if (!active) return
+      recordMotionSample()
+      root.rotateByPointerDelta(delta.x, delta.y)
+    }
+
+    onCanceled: {
+      launchCanceled = true
+      launchPending = false
+      recentVelocityAt = 0
+      root.stopKineticRotation(false)
+    }
+  }
+
+  WheelHandler {
+    id: wheelHandler
+    target: null
+    acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+    blocking: true
+
+    onWheel: function(event) {
       root.interactionStarted()
-      var factor = Math.exp(wheel.angleDelta.y / 720)
+      root.stopKineticRotation(true)
+      root.suppressNextTap = false
+      root.hoveredStation = null
+      var factor = Math.exp(event.angleDelta.y / 720)
       root.globeScale = RadioModel.clamp(
         root.globeScale * factor, root.minimumScale, root.maximumScale)
-      wheel.accepted = true
+      event.accepted = true
+    }
+  }
+
+  FrameAnimation {
+    id: kineticAnimation
+    running: false
+
+    onTriggered: {
+      if (!root.kineticRotationEnabled || frameTime > root.kineticMaximumFrameTime) {
+        root.stopKineticRotation(true)
+        return
+      }
+      if (frameTime <= 0) return
+
+      var step = RadioModel.advanceKineticRotation({
+        longitude: root.centreLongitude,
+        latitude: root.centreLatitude,
+        velocityX: root.kineticVelocityX,
+        velocityY: root.kineticVelocityY
+      }, frameTime, {
+        deceleration: root.kineticDeceleration,
+        scale: root.globeScale,
+        longitudeSensitivity: root.longitudeSensitivity,
+        latitudeSensitivity: root.latitudeSensitivity,
+        minimumLatitude: -78,
+        maximumLatitude: 78
+      })
+      root.kineticVelocityX = step.velocityX
+      root.kineticVelocityY = step.velocityY
+      root.centreLongitude = step.longitude
+      root.centreLatitude = step.latitude
+      if (!step.active) root.finishKineticRotation()
     }
   }
 
   Rectangle {
     id: tooltip
-    visible: !!root.hoveredStation && !pointer.pressed
-    x: Math.min(root.width - width - 8, Math.max(8, root.hoverX + 14))
-    y: Math.min(root.height - height - 8, Math.max(8, root.hoverY + 14))
-    width: Math.min(240, tooltipText.implicitWidth + 20)
-    height: tooltipText.implicitHeight + 14
+    property var station: root.hoveredStation || root.highlightedStation
+    property bool landing: !root.hoveredStation && !!root.highlightedStation
+    property real anchorX: root.hoveredStation ? root.hoverX : root.highlightX
+    property real anchorY: root.hoveredStation ? root.hoverY : root.highlightY
+
+    visible: !!station && !tapHandler.pressed && !dragHandler.active
+      && !kineticAnimation.running
+    x: Math.min(root.width - width - 8, Math.max(8, anchorX + 14))
+    y: Math.min(root.height - height - 8, Math.max(8, anchorY + 14))
+    width: landing
+      ? Math.min(280, Math.max(0, root.width - 16))
+      : Math.min(280, Math.max(0, root.width - 16), tooltipText.implicitWidth + 20)
+    height: tooltipContent.implicitHeight + 14
     color: Qt.rgba(root.backgroundColor.r, root.backgroundColor.g, root.backgroundColor.b, 0.94)
     border.color: root.withAlpha(root.outlineColor, 0.5)
     border.width: 1
     radius: 2
 
-    Text {
-      id: tooltipText
+    Column {
+      id: tooltipContent
       anchors.centerIn: parent
-      width: Math.min(220, implicitWidth)
-      text: root.hoveredStation
-        ? root.hoveredStation.name
-          + (root.hoveredStation.estimatedLocation === true ? " · approximate location" : "")
-        : ""
-      textFormat: Text.PlainText
-      color: root.textColor
-      font.family: root.fontFamily
-      font.pixelSize: 12
-      elide: Text.ElideRight
+      width: Math.max(0, parent.width - 20)
+      spacing: 2
+
+      Text {
+        id: tooltipText
+        width: parent.width
+        text: tooltip.station
+          ? (tooltip.landing ? "Landed near · " : "") + tooltip.station.name
+            + (!tooltip.landing && tooltip.station.estimatedLocation === true
+              ? " · approximate location" : "")
+          : ""
+        textFormat: Text.PlainText
+        color: root.textColor
+        font.family: root.fontFamily
+        font.pixelSize: 12
+        elide: Text.ElideRight
+      }
+
+      Text {
+        width: parent.width
+        visible: tooltip.landing && tooltip.station
+          && tooltip.station.estimatedLocation === true
+        text: "approximate location"
+        textFormat: Text.PlainText
+        color: root.withAlpha(root.textColor, 0.66)
+        font.family: root.fontFamily
+        font.pixelSize: 11
+      }
     }
   }
 }

--- a/Globe.qml
+++ b/Globe.qml
@@ -16,8 +16,6 @@ Item {
   property real maximumScale: 24
   property real longitudeSensitivity: 0.22
   property real latitudeSensitivity: 0.18
-  property bool kineticRotationEnabled: true
-
   readonly property real kineticLaunchSpeed: 120
   readonly property real kineticMaximumSpeed: 2400
   readonly property real kineticDeceleration: 1800
@@ -80,7 +78,6 @@ Item {
   }
 
   function startKineticRotation(velocityX, velocityY) {
-    if (!kineticRotationEnabled) return false
     var launch = RadioModel.kineticLaunchVelocity(
       velocityX, velocityY, kineticLaunchSpeed, kineticMaximumSpeed)
     if (!launch.active) return false
@@ -536,9 +533,6 @@ Item {
     updateHighlightPosition()
     globeCanvas.requestPaint()
   }
-  onKineticRotationEnabledChanged: {
-    if (!kineticRotationEnabled) stopKineticRotation(true)
-  }
   onVisibleChanged: {
     if (!visible) stopKineticRotation(true)
   }
@@ -734,7 +728,7 @@ Item {
     running: false
 
     onTriggered: {
-      if (!root.kineticRotationEnabled || frameTime > root.kineticMaximumFrameTime) {
+      if (frameTime > root.kineticMaximumFrameTime) {
         root.stopKineticRotation(true)
         return
       }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ usual play, pause, previous, and next controls.
 
 ## Features
 
-- Precise drag rotation and deep wheel zoom on a theme-aware globe
+- Kinetic drag rotation that highlights a nearby station when it settles, plus deep wheel zoom on a theme-aware globe
 - A fast cached world view that progressively adds thousands of stations and keeps the session catalog when closed
 - Country stations stay on the session globe and take priority over background signals
 - Country-level map estimates when a station has no published coordinates
@@ -55,7 +55,7 @@ Favorites, listening history, volume, and the selected audio output remain in
 
 | Input | Action |
 | --- | --- |
-| Drag globe | Rotate |
+| Drag or flick globe | Rotate; a flick coasts and highlights a nearby station |
 | Wheel over globe | Zoom |
 | Click signal | Play station |
 | Click country | Browse country |

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -139,7 +139,7 @@ Item {
       title: "MOUSE AND BAR",
       inputWidth: 124,
       controls: [
-        { input: "DRAG GLOBE", action: "Rotate" },
+        { input: "DRAG / FLICK", action: "Spin globe" },
         { input: "GLOBE WHEEL", action: "Zoom" },
         { input: "CLICK SIGNAL", action: "Play station" },
         { input: "CLICK COUNTRY", action: "Browse stations" },
@@ -181,6 +181,7 @@ Item {
   function close() {
     helpVisible = false
     outputMenuOpen = false
+    globe.stopKineticRotation(true)
     opened = false
     worldExpandTimer.stop()
     if (worldExpandProcess.running) worldExpandProcess.running = false
@@ -1377,7 +1378,7 @@ Item {
               ? root.fetchError || root.localError
               : (root.activeCountryName
                 ? root.activeCountryName + "  ·  click another country to browse"
-                : "Drag to rotate  ·  wheel to zoom  ·  click a signal or country")
+                : "Drag or flick to spin  ·  wheel to zoom  ·  click a signal or country")
             textFormat: Text.PlainText
             color: root.fetchError || root.localError ? root.urgent : root.dim
             font.family: Style.font.menuFamily

--- a/RadioModel.js
+++ b/RadioModel.js
@@ -33,7 +33,6 @@ function kineticLaunchVelocity(x, y, minimumSpeed, maximumSpeed) {
   return {
     x: limited.speed >= threshold ? limited.x : 0,
     y: limited.speed >= threshold ? limited.y : 0,
-    speed: limited.speed,
     active: limited.speed >= threshold
   }
 }
@@ -57,10 +56,12 @@ function kineticReleaseVelocity(nativeX, nativeY, sampledX, sampledY,
   var maximumSampleAge = Math.max(0, Number(maximumSampleAgeMilliseconds) || 0)
   var sampleIsFresh = isFinite(sampleAge) && sampleAge >= 0
     && sampleAge <= maximumSampleAge
-  if (sampleIsFresh && sampledSpeed > nativeSpeed) {
-    return { x: sampledVelocityX, y: sampledVelocityY, speed: sampledSpeed }
+  var sampleIsAligned = nativeSpeed === 0
+    || nativeVelocityX * sampledVelocityX + nativeVelocityY * sampledVelocityY > 0
+  if (sampleIsFresh && sampledSpeed > nativeSpeed && sampleIsAligned) {
+    return { x: sampledVelocityX, y: sampledVelocityY }
   }
-  return { x: nativeVelocityX, y: nativeVelocityY, speed: nativeSpeed }
+  return { x: nativeVelocityX, y: nativeVelocityY }
 }
 
 function advanceKineticRotation(state, elapsedSeconds, options) {
@@ -83,8 +84,6 @@ function advanceKineticRotation(state, elapsedSeconds, options) {
       latitude: latitude,
       velocityX: velocityX,
       velocityY: velocityY,
-      deltaX: 0,
-      deltaY: 0,
       active: speed > 0
     }
   }
@@ -127,8 +126,6 @@ function advanceKineticRotation(state, elapsedSeconds, options) {
     latitude: nextLatitude,
     velocityX: nextVelocityX,
     velocityY: nextVelocityY,
-    deltaX: deltaX,
-    deltaY: deltaY,
     active: remainingSpeed > 1e-9
   }
 }

--- a/RadioModel.js
+++ b/RadioModel.js
@@ -12,6 +12,127 @@ function wrapLongitude(value) {
   return wrapped - 180
 }
 
+function limitKineticVelocity(x, y, maximumSpeed) {
+  var velocityX = Number(x)
+  var velocityY = Number(y)
+  var limit = Number(maximumSpeed)
+  if (!isFinite(velocityX) || !isFinite(velocityY) || !isFinite(limit) || limit <= 0)
+    return { x: 0, y: 0, speed: 0 }
+
+  var speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY)
+  if (!isFinite(speed) || speed <= 0) return { x: 0, y: 0, speed: 0 }
+  if (speed <= limit) return { x: velocityX, y: velocityY, speed: speed }
+
+  var ratio = limit / speed
+  return { x: velocityX * ratio, y: velocityY * ratio, speed: limit }
+}
+
+function kineticLaunchVelocity(x, y, minimumSpeed, maximumSpeed) {
+  var limited = limitKineticVelocity(x, y, maximumSpeed)
+  var threshold = Math.max(0, Number(minimumSpeed) || 0)
+  return {
+    x: limited.speed >= threshold ? limited.x : 0,
+    y: limited.speed >= threshold ? limited.y : 0,
+    speed: limited.speed,
+    active: limited.speed >= threshold
+  }
+}
+
+function kineticReleaseVelocity(nativeX, nativeY, sampledX, sampledY,
+                                sampleAgeMilliseconds, maximumSampleAgeMilliseconds) {
+  var nativeVelocityX = Number(nativeX)
+  var nativeVelocityY = Number(nativeY)
+  var sampledVelocityX = Number(sampledX)
+  var sampledVelocityY = Number(sampledY)
+  if (!isFinite(nativeVelocityX)) nativeVelocityX = 0
+  if (!isFinite(nativeVelocityY)) nativeVelocityY = 0
+  if (!isFinite(sampledVelocityX)) sampledVelocityX = 0
+  if (!isFinite(sampledVelocityY)) sampledVelocityY = 0
+
+  var nativeSpeed = Math.sqrt(
+    nativeVelocityX * nativeVelocityX + nativeVelocityY * nativeVelocityY)
+  var sampledSpeed = Math.sqrt(
+    sampledVelocityX * sampledVelocityX + sampledVelocityY * sampledVelocityY)
+  var sampleAge = Number(sampleAgeMilliseconds)
+  var maximumSampleAge = Math.max(0, Number(maximumSampleAgeMilliseconds) || 0)
+  var sampleIsFresh = isFinite(sampleAge) && sampleAge >= 0
+    && sampleAge <= maximumSampleAge
+  if (sampleIsFresh && sampledSpeed > nativeSpeed) {
+    return { x: sampledVelocityX, y: sampledVelocityY, speed: sampledSpeed }
+  }
+  return { x: nativeVelocityX, y: nativeVelocityY, speed: nativeSpeed }
+}
+
+function advanceKineticRotation(state, elapsedSeconds, options) {
+  var current = state || ({})
+  var config = options || ({})
+  var longitude = Number(current.longitude)
+  var latitude = Number(current.latitude)
+  var velocityX = Number(current.velocityX)
+  var velocityY = Number(current.velocityY)
+  var elapsed = Number(elapsedSeconds)
+  if (!isFinite(longitude)) longitude = 0
+  if (!isFinite(latitude)) latitude = 0
+  if (!isFinite(velocityX)) velocityX = 0
+  if (!isFinite(velocityY)) velocityY = 0
+
+  var speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY)
+  if (!isFinite(speed) || speed <= 0 || !isFinite(elapsed) || elapsed <= 0) {
+    return {
+      longitude: wrapLongitude(longitude),
+      latitude: latitude,
+      velocityX: velocityX,
+      velocityY: velocityY,
+      deltaX: 0,
+      deltaY: 0,
+      active: speed > 0
+    }
+  }
+
+  var deceleration = Number(config.deceleration)
+  if (!isFinite(deceleration) || deceleration < 0) deceleration = 0
+  var activeTime = deceleration > 0 ? Math.min(elapsed, speed / deceleration) : elapsed
+  var nextSpeed = Math.max(0, speed - deceleration * activeTime)
+  var distance = (speed + nextSpeed) * activeTime / 2
+  var directionX = velocityX / speed
+  var directionY = velocityY / speed
+  var deltaX = directionX * distance
+  var deltaY = directionY * distance
+
+  var scale = Number(config.scale)
+  if (!isFinite(scale) || scale <= 0) scale = 1
+  var longitudeSensitivity = Number(config.longitudeSensitivity)
+  var latitudeSensitivity = Number(config.latitudeSensitivity)
+  if (!isFinite(longitudeSensitivity)) longitudeSensitivity = 0
+  if (!isFinite(latitudeSensitivity)) latitudeSensitivity = 0
+  var minimumLatitude = Number(config.minimumLatitude)
+  var maximumLatitude = Number(config.maximumLatitude)
+  if (!isFinite(minimumLatitude)) minimumLatitude = -78
+  if (!isFinite(maximumLatitude)) maximumLatitude = 78
+
+  var nextLongitude = wrapLongitude(longitude - deltaX * longitudeSensitivity / scale)
+  var nextLatitude = clamp(
+    latitude + deltaY * latitudeSensitivity / scale,
+    minimumLatitude, maximumLatitude)
+  var nextVelocityX = directionX * nextSpeed
+  var nextVelocityY = directionY * nextSpeed
+  if ((nextLatitude >= maximumLatitude && nextVelocityY > 0)
+      || (nextLatitude <= minimumLatitude && nextVelocityY < 0))
+    nextVelocityY = 0
+
+  var remainingSpeed = Math.sqrt(
+    nextVelocityX * nextVelocityX + nextVelocityY * nextVelocityY)
+  return {
+    longitude: nextLongitude,
+    latitude: nextLatitude,
+    velocityX: nextVelocityX,
+    velocityY: nextVelocityY,
+    deltaX: deltaX,
+    deltaY: deltaY,
+    active: remainingSpeed > 1e-9
+  }
+}
+
 function project(latitude, longitude, centreLatitude, centreLongitude) {
   var phi = Number(latitude) * radians
   var lambda = wrapLongitude(Number(longitude) - Number(centreLongitude)) * radians
@@ -250,6 +371,51 @@ function stationPosition(station, width, height, scale, centreLatitude, centreLo
     y: height / 2 - point.y * radius,
     z: point.z
   }
+}
+
+function nearestVisibleStation(stations, centreLatitude, centreLongitude, excludedUuid,
+                               width, height, scale) {
+  var rows = Array.isArray(stations) ? stations : []
+  var excluded = String(excludedUuid || "")
+  var viewportWidth = Number(width)
+  var viewportHeight = Number(height)
+  var viewportScale = Number(scale)
+  var constrainToViewport = isFinite(viewportWidth) && viewportWidth > 0
+    && isFinite(viewportHeight) && viewportHeight > 0
+    && isFinite(viewportScale) && viewportScale > 0
+  var viewportRadius = constrainToViewport
+    ? Math.min(viewportWidth, viewportHeight) * 0.44 * viewportScale : 0
+  var nearest = null
+  var nearestDepth = -Infinity
+  var preferred = null
+  var preferredDepth = -Infinity
+
+  for (var i = 0; i < rows.length; i++) {
+    var station = rows[i]
+    if (!station || station.latitude === null || station.longitude === null) continue
+    var latitude = Number(station.latitude)
+    var longitude = Number(station.longitude)
+    if (!isFinite(latitude) || !isFinite(longitude)) continue
+    var point = project(latitude, longitude, centreLatitude, centreLongitude)
+    if (!isFinite(point.z) || point.z < 0) continue
+    if (constrainToViewport) {
+      var screenX = viewportWidth / 2 + point.x * viewportRadius
+      var screenY = viewportHeight / 2 - point.y * viewportRadius
+      if (screenX < 0 || screenX > viewportWidth
+          || screenY < 0 || screenY > viewportHeight)
+        continue
+    }
+    if (point.z > nearestDepth) {
+      nearest = station
+      nearestDepth = point.z
+    }
+    if (String(station.uuid || "") !== excluded && point.z > preferredDepth) {
+      preferred = station
+      preferredDepth = point.z
+    }
+  }
+
+  return preferred || nearest
 }
 
 function stationAt(stations, x, y, width, height, scale, centreLatitude, centreLongitude, hitRadius) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "akshar.radio-atlas",
   "name": "Radio Atlas",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Akshar Patel",
   "license": "MIT",
   "description": "Explore live radio on a rotatable globe and play stations through Omarchy's media controls.",

--- a/tests/model.test.mjs
+++ b/tests/model.test.mjs
@@ -28,9 +28,9 @@ const acceptedKineticVelocity = model.kineticLaunchVelocity(120, 0, 120, 2400)
 assert.equal(acceptedKineticVelocity.active, true)
 const cappedKineticVelocity = model.kineticLaunchVelocity(3000, 4000, 120, 2400)
 assert.equal(cappedKineticVelocity.active, true)
-approximatelyEqual(cappedKineticVelocity.speed, 2400)
 approximatelyEqual(cappedKineticVelocity.x, 1440)
 approximatelyEqual(cappedKineticVelocity.y, 1920)
+approximatelyEqual(Math.hypot(cappedKineticVelocity.x, cappedKineticVelocity.y), 2400)
 
 const sampledReleaseVelocity = model.kineticReleaseVelocity(60, 20, 300, -40, 20, 100)
 approximatelyEqual(sampledReleaseVelocity.x, 300)
@@ -44,6 +44,12 @@ approximatelyEqual(fasterNativeReleaseVelocity.y, 0)
 const invalidReleaseVelocity = model.kineticReleaseVelocity(60, 20, 300, -40, Number.NaN, 100)
 approximatelyEqual(invalidReleaseVelocity.x, 60)
 approximatelyEqual(invalidReleaseVelocity.y, 20)
+const reversedReleaseVelocity = model.kineticReleaseVelocity(60, 20, -300, -40, 20, 100)
+approximatelyEqual(reversedReleaseVelocity.x, 60)
+approximatelyEqual(reversedReleaseVelocity.y, 20)
+const zeroNativeReleaseVelocity = model.kineticReleaseVelocity(0, 0, -300, -40, 20, 100)
+approximatelyEqual(zeroNativeReleaseVelocity.x, -300)
+approximatelyEqual(zeroNativeReleaseVelocity.y, -40)
 
 const kineticOptions = {
   deceleration: 1800,
@@ -68,7 +74,6 @@ const exactKineticStop = model.advanceKineticRotation({
   velocityY: 0
 }, 1, kineticOptions)
 assert.equal(exactKineticStop.active, false)
-approximatelyEqual(exactKineticStop.deltaX, 100)
 approximatelyEqual(exactKineticStop.longitude, -22)
 
 const kineticAt30 = simulateKineticRotation(30, {

--- a/tests/model.test.mjs
+++ b/tests/model.test.mjs
@@ -10,9 +10,119 @@ const model = { Math, Number, Array, String, isFinite }
 vm.createContext(model)
 vm.runInContext(source, model)
 
+function approximatelyEqual(actual, expected, tolerance = 1e-9) {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`
+  )
+}
+
 assert.equal(model.clamp(12, 0, 10), 10)
 assert.equal(model.wrapLongitude(190), -170)
 assert.equal(model.wrapLongitude(-190), 170)
+
+const rejectedKineticVelocity = model.kineticLaunchVelocity(119, 0, 120, 2400)
+assert.equal(rejectedKineticVelocity.active, false)
+assert.equal(rejectedKineticVelocity.x, 0)
+const acceptedKineticVelocity = model.kineticLaunchVelocity(120, 0, 120, 2400)
+assert.equal(acceptedKineticVelocity.active, true)
+const cappedKineticVelocity = model.kineticLaunchVelocity(3000, 4000, 120, 2400)
+assert.equal(cappedKineticVelocity.active, true)
+approximatelyEqual(cappedKineticVelocity.speed, 2400)
+approximatelyEqual(cappedKineticVelocity.x, 1440)
+approximatelyEqual(cappedKineticVelocity.y, 1920)
+
+const sampledReleaseVelocity = model.kineticReleaseVelocity(60, 20, 300, -40, 20, 100)
+approximatelyEqual(sampledReleaseVelocity.x, 300)
+approximatelyEqual(sampledReleaseVelocity.y, -40)
+const staleReleaseVelocity = model.kineticReleaseVelocity(60, 20, 300, -40, 101, 100)
+approximatelyEqual(staleReleaseVelocity.x, 60)
+approximatelyEqual(staleReleaseVelocity.y, 20)
+const fasterNativeReleaseVelocity = model.kineticReleaseVelocity(400, 0, 300, -40, 20, 100)
+approximatelyEqual(fasterNativeReleaseVelocity.x, 400)
+approximatelyEqual(fasterNativeReleaseVelocity.y, 0)
+const invalidReleaseVelocity = model.kineticReleaseVelocity(60, 20, 300, -40, Number.NaN, 100)
+approximatelyEqual(invalidReleaseVelocity.x, 60)
+approximatelyEqual(invalidReleaseVelocity.y, 20)
+
+const kineticOptions = {
+  deceleration: 1800,
+  scale: 1,
+  longitudeSensitivity: 0.22,
+  latitudeSensitivity: 0.18,
+  minimumLatitude: -78,
+  maximumLatitude: 78
+}
+
+function simulateKineticRotation(framesPerSecond, initialState) {
+  var state = initialState
+  for (var frame = 0; frame < framesPerSecond * 3 && state.active !== false; frame++)
+    state = model.advanceKineticRotation(state, 1 / framesPerSecond, kineticOptions)
+  return state
+}
+
+const exactKineticStop = model.advanceKineticRotation({
+  longitude: 0,
+  latitude: 0,
+  velocityX: 600,
+  velocityY: 0
+}, 1, kineticOptions)
+assert.equal(exactKineticStop.active, false)
+approximatelyEqual(exactKineticStop.deltaX, 100)
+approximatelyEqual(exactKineticStop.longitude, -22)
+
+const kineticAt30 = simulateKineticRotation(30, {
+  longitude: 0,
+  latitude: 0,
+  velocityX: 1200,
+  velocityY: 0,
+  active: true
+})
+const kineticAt60 = simulateKineticRotation(60, {
+  longitude: 0,
+  latitude: 0,
+  velocityX: 1200,
+  velocityY: 0,
+  active: true
+})
+const kineticAt120 = simulateKineticRotation(120, {
+  longitude: 0,
+  latitude: 0,
+  velocityX: 1200,
+  velocityY: 0,
+  active: true
+})
+approximatelyEqual(kineticAt30.longitude, -88)
+approximatelyEqual(kineticAt60.longitude, kineticAt30.longitude)
+approximatelyEqual(kineticAt120.longitude, kineticAt30.longitude)
+assert.equal(kineticAt120.active, false)
+
+const wrappedKineticStop = model.advanceKineticRotation({
+  longitude: 179,
+  latitude: 0,
+  velocityX: -600,
+  velocityY: 0
+}, 1, kineticOptions)
+approximatelyEqual(wrappedKineticStop.longitude, -159)
+
+const poleKineticStep = model.advanceKineticRotation({
+  longitude: 0,
+  latitude: 77,
+  velocityX: 600,
+  velocityY: 600
+}, 0.05, kineticOptions)
+assert.equal(poleKineticStep.latitude, 78)
+assert.equal(poleKineticStep.velocityY, 0)
+assert.ok(poleKineticStep.velocityX > 0)
+assert.equal(poleKineticStep.active, true)
+
+const invalidKineticStep = model.advanceKineticRotation({
+  longitude: 0,
+  latitude: 0,
+  velocityX: Number.NaN,
+  velocityY: Number.POSITIVE_INFINITY
+}, 0.016, kineticOptions)
+assert.equal(invalidKineticStep.active, false)
 
 const centre = model.project(0, 0, 0, 0)
 assert.ok(Math.abs(centre.x) < 1e-9)
@@ -46,6 +156,32 @@ const stations = [
 ]
 assert.equal(model.stationAt(stations, 100, 100, 200, 200, 1, 0, 0, 12).uuid, "a")
 assert.equal(model.compactTags("jazz, soul, jazz", 2), "jazz · soul")
+
+const landingStations = [
+  { uuid: "playing", name: "Playing", latitude: 0, longitude: 0 },
+  { uuid: "nearby", name: "Nearby", latitude: 0, longitude: 10 },
+  { uuid: "horizon", name: "Horizon", latitude: 0, longitude: 90 },
+  { uuid: "hidden", name: "Hidden", latitude: 0, longitude: 180 }
+]
+const landingSnapshot = JSON.stringify(landingStations)
+assert.equal(model.nearestVisibleStation(landingStations, 0, 0, "").uuid, "playing")
+assert.equal(model.nearestVisibleStation(landingStations, 0, 0, "playing").uuid, "nearby")
+assert.equal(model.nearestVisibleStation([landingStations[0]], 0, 0, "playing").uuid, "playing")
+assert.equal(model.nearestVisibleStation([landingStations[3]], 0, 0, ""), null)
+assert.equal(JSON.stringify(landingStations), landingSnapshot)
+
+const zoomedLandingStations = [
+  { uuid: "offscreen", name: "Off-screen", latitude: 0, longitude: 10 },
+  { uuid: "onscreen", name: "On-screen", latitude: 0, longitude: 1 }
+]
+assert.equal(
+  model.nearestVisibleStation(zoomedLandingStations, 0, 0, "", 600, 600, 24).uuid,
+  "onscreen"
+)
+assert.equal(
+  model.nearestVisibleStation([zoomedLandingStations[0]], 0, 0, "", 600, 600, 24),
+  null
+)
 
 const worldStations = [
   { uuid: "world", name: "World", latitude: 1, longitude: 1 },

--- a/tests/run
+++ b/tests/run
@@ -6,7 +6,7 @@ project_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 jq -e '
   .schemaVersion == 1
   and .id == "akshar.radio-atlas"
-  and .version == "0.1.5"
+  and .version == "0.1.6"
   and (.kinds | index("overlay"))
   and (.kinds | index("bar-widget"))
   and .keepLoaded == true
@@ -20,16 +20,6 @@ node "$project_dir/tests/model.test.mjs"
 python3 "$project_dir/tests/proxy.test.py"
 ! rg -q 'playerStatusProcess|refreshPlayerStatus' \
   "$project_dir/BarWidget.qml" "$project_dir/RadioAtlas.qml"
-rg -q 'property bool kineticRotationEnabled: true' "$project_dir/Globe.qml"
-rg -Fq 'function stopKineticRotation(clearLanding)' "$project_dir/Globe.qml"
-rg -q 'centroid\.velocity' "$project_dir/Globe.qml"
-rg -q 'kineticReleaseVelocity' "$project_dir/Globe.qml" "$project_dir/RadioModel.js"
-rg -q 'recordMotionSample' "$project_dir/Globe.qml"
-rg -q 'FrameAnimation' "$project_dir/Globe.qml"
-rg -q 'onKineticRotationEnabledChanged' "$project_dir/Globe.qml"
-rg -q 'onVisibleChanged' "$project_dir/Globe.qml"
-sed -n '/function close()/,/^  }/p' "$project_dir/RadioAtlas.qml" \
-  | rg -Fq 'globe.stopKineticRotation(true)'
 rg -q 'maximumScale: 24' "$project_dir/Globe.qml"
 rg -q 'searchDebounce.restart()' "$project_dir/RadioAtlas.qml"
 rg -q 'property bool helpVisible: false' "$project_dir/RadioAtlas.qml"
@@ -39,8 +29,6 @@ sed -n '/function close()/,/^  }/p' "$project_dir/RadioAtlas.qml" \
   | rg -Fq 'helpVisible = false'
 rg -q 'id: controlsPane' "$project_dir/RadioAtlas.qml"
 rg -Fq '{ input: "?", action: "Show or hide controls" }' \
-  "$project_dir/RadioAtlas.qml"
-rg -Fq '{ input: "DRAG / FLICK", action: "Spin globe" }' \
   "$project_dir/RadioAtlas.qml"
 sed -n '/Keys.onPressed: function(event)/,/^        }/p' "$project_dir/RadioAtlas.qml" \
   | rg -Fq 'root.isHelpKey(event)'

--- a/tests/run
+++ b/tests/run
@@ -20,7 +20,16 @@ node "$project_dir/tests/model.test.mjs"
 python3 "$project_dir/tests/proxy.test.py"
 ! rg -q 'playerStatusProcess|refreshPlayerStatus' \
   "$project_dir/BarWidget.qml" "$project_dir/RadioAtlas.qml"
-! rg -q 'inertia' "$project_dir/Globe.qml"
+rg -q 'property bool kineticRotationEnabled: true' "$project_dir/Globe.qml"
+rg -Fq 'function stopKineticRotation(clearLanding)' "$project_dir/Globe.qml"
+rg -q 'centroid\.velocity' "$project_dir/Globe.qml"
+rg -q 'kineticReleaseVelocity' "$project_dir/Globe.qml" "$project_dir/RadioModel.js"
+rg -q 'recordMotionSample' "$project_dir/Globe.qml"
+rg -q 'FrameAnimation' "$project_dir/Globe.qml"
+rg -q 'onKineticRotationEnabledChanged' "$project_dir/Globe.qml"
+rg -q 'onVisibleChanged' "$project_dir/Globe.qml"
+sed -n '/function close()/,/^  }/p' "$project_dir/RadioAtlas.qml" \
+  | rg -Fq 'globe.stopKineticRotation(true)'
 rg -q 'maximumScale: 24' "$project_dir/Globe.qml"
 rg -q 'searchDebounce.restart()' "$project_dir/RadioAtlas.qml"
 rg -q 'property bool helpVisible: false' "$project_dir/RadioAtlas.qml"
@@ -30,6 +39,8 @@ sed -n '/function close()/,/^  }/p' "$project_dir/RadioAtlas.qml" \
   | rg -Fq 'helpVisible = false'
 rg -q 'id: controlsPane' "$project_dir/RadioAtlas.qml"
 rg -Fq '{ input: "?", action: "Show or hide controls" }' \
+  "$project_dir/RadioAtlas.qml"
+rg -Fq '{ input: "DRAG / FLICK", action: "Spin globe" }' \
   "$project_dir/RadioAtlas.qml"
 sed -n '/Keys.onPressed: function(event)/,/^        }/p' "$project_dir/RadioAtlas.qml" \
   | rg -Fq 'root.isHelpKey(event)'


### PR DESCRIPTION
A quick globe flick currently stops as soon as the pointer is released, which makes exploration feel stiff. This adds bounded kinetic rotation and a visual hint for the station nearest the center when the globe settles. The hint does not select or play anything.

## What changed

- Use Qt pointer handlers so mouse and touch share one gesture path.
- Carry an aligned release velocity into frame-time-based motion with a launch floor, speed cap, fixed deceleration, and exact stop.
- Cancel motion on re-grab, wheel input, programmatic focus, close, visibility loss, canceled grabs, or a long suspended frame.
- Highlight the nearest visible station when motion settles, preferring a station other than the current selection.
- Update the controls copy and bump the plugin version to 0.1.6.

Vertical rotation across the poles remains outside this PR and is tracked in #5.

## Verification

- `./tests/run`
- `qmllint -I /usr/share/omarchy/shell BarWidget.qml Globe.qml RadioAtlas.qml`
- `omarchy plugin validate .`
- Model tests cover release-direction preservation, launch bounds, frame-rate equivalence, finite stopping, longitude wrapping, pole clamping, and landing preference.
- Manual Omarchy testing covered mouse flicks, re-grab cancellation, wheel cancellation, and the landing highlight.
