### PR TITLE
Add an audio output picker with AirPlay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ usual play, pause, previous, and next controls.
 - Instant cached results while full-directory search and country browsing refresh from Radio Browser
 - Random tuning that avoids recent stations, plus favorites and listening history
 - Independent volume slider, mute, and bar-wheel volume control
+- Audio output picker that routes radio to any PipeWire sink, including AirPlay speakers exposed as RAOP sinks
 - Click-through desktop focus outside the atlas panel
 - Automatic dismissal when Omarchy starts its screensaver
 - Keyboard navigation
@@ -66,11 +67,51 @@ Favorites, listening history, and the saved volume remain in
 | `F` | Favorite selected station |
 | `+` / `-` | Raise or lower radio volume |
 | `M` | Mute or unmute |
+| Speaker icon | Choose the audio output |
 | `?` | Show or hide controls |
 | Escape | Hide controls, clear search, or close |
 
 On the bar, left click opens Radio Atlas, middle click tunes randomly, right
 click stops its player, and the mouse wheel adjusts radio volume.
+
+## Audio outputs and AirPlay
+
+The speaker button next to the volume slider chooses where radio plays. It lists
+every PipeWire output device through `pactl`, which ships with Omarchy's
+PipeWire setup. "System default" follows the desktop's current output, the
+choice is saved alongside the volume in `~/.local/share/radio-atlas/state.json`,
+and switching while playing takes effect immediately. If the chosen device
+disappears, for example an AirPlay speaker that is turned off, mpv falls back to
+the default output and radio keeps playing.
+
+AirPlay speakers appear in this list once PipeWire exposes them as RAOP sinks.
+On Arch Linux, the RAOP modules ship in the optional `pipewire-zeroconf`
+package. Install it, enable discovery, and restart the user services:
+
+```bash
+sudo pacman -S pipewire-zeroconf
+mkdir -p ~/.config/pipewire/pipewire.conf.d
+cp /usr/share/pipewire/pipewire.conf.avail/50-raop.conf \
+  ~/.config/pipewire/pipewire.conf.d/
+systemctl --user restart pipewire wireplumber
+```
+
+If you run a firewall such as ufw, allow the timing feedback AirPlay speakers
+send back to the sender on UDP ports 6001-6002; without it the session connects
+but the speaker stays silent:
+
+```bash
+sudo ufw allow in from 192.168.0.0/16 to any port 6001:6002 proto udp
+```
+
+PipeWire's RAOP discovery occasionally drops a sink when a device briefly
+stops announcing itself over mDNS. If an AirPlay speaker disappears from the
+output list, re-discover it with `systemctl --user restart pipewire wireplumber`.
+
+PipeWire's RAOP sink streams classic AirPlay audio as uncompressed PCM.
+AirPort Express, Apple TV, many AV receivers, and HomePods accept it; AirPlay 2
+only features such as HomePod stereo pairs are not supported. A device that
+refuses the stream simply stays silent; pick another output to recover.
 
 ## Data and privacy
 

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -46,7 +46,16 @@ Item {
   property int playerVolume: 70
   property int reportedVolume: 70
   property int pendingVolume: -1
-  property string playerTitle: ""
+  property string playerOutput: ""
+  property var audioOutputs: []
+  property string outputsError: ""
+  property bool outputMenuOpen: false
+  readonly property var outputChoices: {
+    var rows = [{ id: "", label: "System default" }]
+    for (var i = 0; i < audioOutputs.length; i++) rows.push(audioOutputs[i])
+    return rows
+  }
+
   property var playingStation: null
   property string playingStationUuid: ""
   property string recordedStationUuid: ""
@@ -136,7 +145,8 @@ Item {
         { input: "BAR LEFT", action: "Open or close" },
         { input: "BAR MIDDLE", action: "Tune randomly" },
         { input: "BAR RIGHT", action: "Stop playback" },
-        { input: "BAR WHEEL", action: "Change volume" }
+        { input: "BAR WHEEL", action: "Change volume" },
+        { input: "SPEAKER", action: "Choose audio output" }
       ]
     }
   ]
@@ -148,6 +158,7 @@ Item {
 
   function toggleControls() {
     helpVisible = !helpVisible
+    outputMenuOpen = false
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
 
@@ -168,6 +179,7 @@ Item {
 
   function close() {
     helpVisible = false
+    outputMenuOpen = false
     opened = false
     worldExpandTimer.stop()
     if (worldExpandProcess.running) worldExpandProcess.running = false
@@ -489,6 +501,8 @@ Item {
       playerRunning = state.running === true
       playerPaused = state.paused === true
       playerMuted = state.muted === true
+      playerOutput = /^[A-Za-z0-9._:+-]{0,160}$/.test(String(state.output || ""))
+        ? String(state.output) : ""
       var nextVolume = Math.round(Number(state.volume === undefined ? 70 : state.volume))
       reportedVolume = isFinite(nextVolume) ? Math.max(0, Math.min(100, nextVolume)) : 70
       if (pendingVolume < 0) playerVolume = reportedVolume
@@ -550,6 +564,42 @@ Item {
     volumeProcess.errorOutput = ""
     volumeProcess.command = [root.playerPath, "volume", String(pendingVolume)]
     volumeProcess.running = true
+  }
+
+  function refreshOutputs() {
+    if (outputsProcess.running) return
+    outputsError = ""
+    outputsProcess.output = ""
+    outputsProcess.errorOutput = ""
+    outputsProcess.command = [playerPath, "outputs"]
+    outputsProcess.running = true
+  }
+
+  function selectOutput(value) {
+    var sink = String(value || "")
+    if (outputProcess.running) return
+    playerError = ""
+    outputProcess.submittedOutput = sink
+    outputProcess.output = ""
+    outputProcess.errorOutput = ""
+    outputProcess.command = [playerPath, "output", sink ? sink : "default"]
+    outputProcess.running = true
+  }
+
+  function toggleOutputMenu() {
+    if (outputMenuOpen) {
+      outputMenuOpen = false
+      return
+    }
+    outputMenuOpen = true
+    refreshOutputs()
+  }
+
+  function outputLabel(sink) {
+    for (var i = 0; i < audioOutputs.length; i++) {
+      if (audioOutputs[i].id === sink) return audioOutputs[i].label
+    }
+    return sink
   }
 
   function loadState() {
@@ -860,6 +910,74 @@ Item {
         return
       }
       Qt.callLater(root.flushPlayerVolume)
+    }
+  }
+
+  Process {
+    id: outputsProcess
+    property string output: ""
+    property string errorOutput: ""
+    command: []
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: outputsProcess.output = text
+    }
+    stderr: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: outputsProcess.errorOutput = text
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.outputsError = "Audio outputs are unavailable"
+        return
+      }
+      var parsed = null
+      try {
+        var document = JSON.parse(outputsProcess.output || "{}")
+        if (document && Array.isArray(document.outputs)) parsed = document.outputs
+      } catch (error) {
+        parsed = null
+      }
+      if (parsed === null) {
+        root.outputsError = "Audio outputs are unavailable"
+        return
+      }
+      root.audioOutputs = parsed.filter(function(row) {
+        return row && typeof row === "object"
+          && /^[A-Za-z0-9._:+-]{1,160}$/.test(String(row.id || ""))
+      }).map(function(row) {
+        return {
+          id: String(row.id),
+          label: String(row.label || row.id).replace(/[\r\n\t]+/g, " ").slice(0, 160)
+        }
+      }).slice(0, 16)
+      root.outputsError = ""
+    }
+  }
+
+  Process {
+    id: outputProcess
+    property string submittedOutput: ""
+    property string output: ""
+    property string errorOutput: ""
+    command: []
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: outputProcess.output = text
+    }
+    stderr: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: outputProcess.errorOutput = text
+    }
+    onExited: function(exitCode) {
+      if (exitCode === 0) {
+        root.statusReady = true
+        root.playerError = ""
+        root.playerOutput = outputProcess.submittedOutput
+        root.outputMenuOpen = false
+        return
+      }
+      root.playerError = "Could not change audio output"
     }
   }
 
@@ -1620,6 +1738,19 @@ Item {
 
               Button {
                 anchors.verticalCenter: parent.verticalCenter
+                iconText: "\uf0a1"
+                tooltipText: root.playerOutput
+                  ? "Audio output: " + root.outputLabel(root.playerOutput)
+                  : "Choose audio output"
+                active: root.playerOutput !== ""
+                enabled: !stopProcess.running && !outputProcess.running
+                foreground: root.foreground
+                accent: root.accent
+                onClicked: root.toggleOutputMenu()
+              }
+
+              Button {
+                anchors.verticalCenter: parent.verticalCenter
                 iconText: root.playerMuted || root.playerVolume === 0 ? "\uf026" : "\uf028"
                 tooltipText: root.playerMuted ? "Unmute" : "Mute (M)"
                 active: root.playerMuted
@@ -1659,6 +1790,83 @@ Item {
                 font.family: Style.font.menuFamily
                 font.pixelSize: Style.font.caption
                 horizontalAlignment: Text.AlignRight
+              }
+            }
+          }
+
+          MouseArea {
+            visible: root.outputMenuOpen
+            anchors.fill: parent
+            z: 2
+            onClicked: root.outputMenuOpen = false
+          }
+
+          Rectangle {
+            id: outputMenu
+            visible: root.outputMenuOpen
+            anchors.right: parent.right
+            anchors.rightMargin: Style.spacing.sm
+            anchors.bottom: playerPanel.top
+            anchors.bottomMargin: Style.spacing.xs
+            z: 3
+            width: Math.min(Style.space(300), parent.width - Style.spacing.md * 2)
+            height: outputMenuColumn.implicitHeight + Style.spacing.md * 2
+            radius: Style.cornerRadius
+            color: root.background
+            border.color: root.faint
+            border.width: 1
+
+            Accessible.role: Accessible.Pane
+            Accessible.name: "Audio output"
+
+            Column {
+              id: outputMenuColumn
+              anchors.top: parent.top
+              anchors.topMargin: Style.spacing.md
+              anchors.left: parent.left
+              anchors.right: parent.right
+              spacing: Style.spacing.xs
+
+              Text {
+                anchors.left: parent.left
+                anchors.leftMargin: Style.spacing.xs
+                text: "AUDIO OUTPUT"
+                textFormat: Text.PlainText
+                color: root.dim
+                font.family: Style.font.menuFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+              }
+
+              Repeater {
+                model: root.outputChoices
+
+                delegate: Button {
+                  id: outputOption
+                  required property var modelData
+                  width: parent.width
+                  leftAlign: true
+                  text: outputOption.modelData.label
+                  selected: outputOption.modelData.id === root.playerOutput
+                  foreground: root.foreground
+                  accent: root.accent
+                  Accessible.role: Accessible.Button
+                  Accessible.name: outputOption.modelData.label
+                  onClicked: root.selectOutput(outputOption.modelData.id)
+                }
+              }
+
+              Text {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Style.spacing.xs
+                visible: root.audioOutputs.length === 0 && !outputsProcess.running
+                text: root.outputsError || "No other audio outputs found"
+                textFormat: Text.PlainText
+                color: root.outputsError ? root.urgent : root.dim
+                font.family: Style.font.menuFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.Wrap
               }
             }
           }

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -583,7 +583,9 @@ Item {
     outputProcess.submittedOutput = sink
     outputProcess.output = ""
     outputProcess.errorOutput = ""
-    outputProcess.command = [playerPath, "output", sink ? sink : "default"]
+    outputProcess.command = sink
+      ? [playerPath, "output", sink]
+      : [playerPath, "output"]
     outputProcess.running = true
   }
 
@@ -1747,6 +1749,7 @@ Item {
                   : "Choose audio output"
                 active: root.playerOutput !== ""
                 enabled: !stopProcess.running && !outputProcess.running
+                focusable: true
                 foreground: root.foreground
                 accent: root.accent
                 onClicked: root.toggleOutputMenu()
@@ -1861,6 +1864,7 @@ Item {
                   leftAlign: true
                   text: outputOption.modelData.label
                   selected: outputOption.modelData.id === root.playerOutput
+                  focusable: true
                   foreground: root.foreground
                   accent: root.accent
                   Accessible.role: Accessible.Button

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -953,7 +953,7 @@ Item {
           id: String(row.id),
           label: String(row.label || row.id).replace(/[\r\n\t]+/g, " ").slice(0, 160)
         }
-      }).slice(0, 16)
+      })
       root.outputsError = ""
     }
   }
@@ -1841,13 +1841,23 @@ Item {
                 font.bold: true
               }
 
-              Repeater {
+              ListView {
+                id: outputList
+                width: parent.width
+                height: Math.min(contentHeight, Style.space(320))
                 model: root.outputChoices
+                spacing: Style.spacing.xs
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+
+                QQC.ScrollBar.vertical: QQC.ScrollBar {
+                  policy: QQC.ScrollBar.AsNeeded
+                }
 
                 delegate: Button {
                   id: outputOption
                   required property var modelData
-                  width: parent.width
+                  width: ListView.view.width
                   leftAlign: true
                   text: outputOption.modelData.label
                   selected: outputOption.modelData.id === root.playerOutput

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -46,6 +46,7 @@ Item {
   property int playerVolume: 70
   property int reportedVolume: 70
   property int pendingVolume: -1
+  property string playerTitle: ""
   property string playerOutput: ""
   property var audioOutputs: []
   property string outputsError: ""
@@ -929,6 +930,7 @@ Item {
     onExited: function(exitCode) {
       if (exitCode !== 0) {
         root.outputsError = "Audio outputs are unavailable"
+        root.audioOutputs = []
         return
       }
       var parsed = null
@@ -940,6 +942,7 @@ Item {
       }
       if (parsed === null) {
         root.outputsError = "Audio outputs are unavailable"
+        root.audioOutputs = []
         return
       }
       root.audioOutputs = parsed.filter(function(row) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "akshar.radio-atlas",
   "name": "Radio Atlas",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": "Akshar Patel",
   "license": "MIT",
   "description": "Explore live radio on a rotatable globe and play stations through Omarchy's media controls.",

--- a/radio-player
+++ b/radio-player
@@ -331,7 +331,6 @@ set_output() {
   fi
 
   "$state_path" get >/dev/null
-  "$state_path" output "$requested" >/dev/null
   if [[ -S $socket ]]; then
     local device command
     device=auto
@@ -345,6 +344,7 @@ set_output() {
       fi
     fi
   fi
+  "$state_path" output "$requested" >/dev/null
   status
 }
 

--- a/radio-player
+++ b/radio-player
@@ -211,7 +211,7 @@ status() {
     playlistCount: ([.[] | select(.request_id == 4) | .data][0] // 0),
     volume: ([.[] | select(.request_id == 5) | .data][0] // 70),
     output: (([.[] | select(.request_id == 7) | .data][0] // "")
-      | if type == "string" then (sub("^pipewire/"; "") | if . == "auto" then "" else . end) else "" end),
+      | if type == "string" then (if . == "auto" then "" else sub("^pipewire/"; "") end) else "" end),
     loaded: $loaded,
     station: $station
   }' <<< "$response")"

--- a/radio-player
+++ b/radio-player
@@ -315,8 +315,7 @@ list_outputs() {
 }
 
 set_output() {
-  local requested=${1:-default}
-  [[ $requested == default ]] && requested=""
+  local requested=${1-}
   if [[ -n $requested ]]; then
     [[ $requested =~ ^[A-Za-z0-9._:+-]{1,160}$ ]] || {
       echo 'Unknown audio output' >&2
@@ -559,7 +558,7 @@ case "$action" in
     list_outputs
     ;;
   output)
-    set_output "${2:-default}"
+    set_output "${2-}"
     ;;
   stop)
     stop_player

--- a/radio-player
+++ b/radio-player
@@ -111,6 +111,13 @@ persist_volume() {
   local volume=$1
   "$state_path" volume "$volume" >/dev/null
 }
+configured_output() {
+  local output
+  output=$("$state_path" get 2>/dev/null \
+    | jq -r '(.output // "") | if (type == "string" and test("^([A-Za-z0-9._:+-]{0,160})$")) then . else "" end') \
+    || output=""
+  printf '%s\n' "$output"
+}
 
 write_status() {
   local state=$1
@@ -143,7 +150,7 @@ send_command() {
 status() {
   if [[ ! -S $socket ]]; then
     cleanup_dead_player
-    write_status "$(jq -cn --argjson volume "$(configured_volume)" '{running:false,paused:false,muted:false,title:"",playlistPosition:-1,playlistCount:0,volume:$volume,loaded:false,station:{}}')"
+    write_status "$(jq -cn --argjson volume "$(configured_volume)" --arg output "$(configured_output)" '{running:false,paused:false,muted:false,title:"",playlistPosition:-1,playlistCount:0,volume:$volume,output:$output,loaded:false,station:{}}')"
     return
   fi
 
@@ -156,6 +163,7 @@ status() {
       '{"command":["get_property","playlist-count"],"request_id":4}' \
       '{"command":["get_property","volume"],"request_id":5}' \
       '{"command":["get_property","mute"],"request_id":6}' \
+      '{"command":["get_property","audio-device"],"request_id":7}' \
       | socat -T 1 - "UNIX-CONNECT:$socket" 2>/dev/null \
       | head -c "$((max_ipc_bytes + 1))" || true
   )
@@ -165,7 +173,7 @@ status() {
 
   if ! jq -e 'select(.request_id == 1)' <<< "$response" >/dev/null 2>&1; then
     cleanup_dead_player
-    write_status "$(jq -cn --argjson volume "$(configured_volume)" '{running:false,paused:false,muted:false,title:"",playlistPosition:-1,playlistCount:0,volume:$volume,loaded:false,station:{}}')"
+    write_status "$(jq -cn --argjson volume "$(configured_volume)" --arg output "$(configured_output)" '{running:false,paused:false,muted:false,title:"",playlistPosition:-1,playlistCount:0,volume:$volume,output:$output,loaded:false,station:{}}')"
     return
   fi
 
@@ -202,6 +210,8 @@ status() {
     playlistPosition: ([.[] | select(.request_id == 3) | .data][0] // -1),
     playlistCount: ([.[] | select(.request_id == 4) | .data][0] // 0),
     volume: ([.[] | select(.request_id == 5) | .data][0] // 70),
+    output: (([.[] | select(.request_id == 7) | .data][0] // "")
+      | if type == "string" then (sub("^pipewire/"; "") | if . == "auto" then "" else . end) else "" end),
     loaded: $loaded,
     station: $station
   }' <<< "$response")"
@@ -276,6 +286,66 @@ adjust_volume() {
   (( next < 0 )) && next=0
   (( next > 100 )) && next=100
   set_volume "$next"
+}
+
+list_outputs() {
+  local sinks
+  sinks=$(pactl -f json list sinks 2>/dev/null) || {
+    echo 'Audio outputs are unavailable' >&2
+    exit 3
+  }
+  if (( $(printf '%s' "$sinks" | wc -c) > max_json_bytes )) \
+    || ! jq -e 'type == "array"' <<< "$sinks" >/dev/null 2>&1; then
+    echo 'Audio outputs are unavailable' >&2
+    exit 3
+  fi
+  printf '%s' "$sinks" | jq -c '[
+    .[] | select(type == "object")
+    | {
+        id: (.name | tostring | select(test("^([A-Za-z0-9._:+-]{1,160})$"))),
+        label: (if (.name | tostring | startswith("raop_sink."))
+          then ((.description // .name | tostring)
+            + " · " + (.name | tostring | split(".") | .[-5:-1] | join(".")))
+          else (.description // .name | tostring) end
+          | gsub("[\\r\\n\\t]"; " ") | .[:160])
+      }
+    | select(.id != null)
+  ][0:16] | {outputs: .}'
+}
+
+set_output() {
+  local requested=${1:-default}
+  [[ $requested == default ]] && requested=""
+  if [[ -n $requested ]]; then
+    [[ $requested =~ ^[A-Za-z0-9._:+-]{1,160}$ ]] || {
+      echo 'Unknown audio output' >&2
+      exit 2
+    }
+    local available
+    available=$(list_outputs)
+    jq -e --arg requested "$requested" 'any(.outputs[]; .id == $requested)' \
+      <<< "$available" >/dev/null || {
+      echo 'Unknown audio output' >&2
+      exit 3
+    }
+  fi
+
+  "$state_path" get >/dev/null
+  "$state_path" output "$requested" >/dev/null
+  if [[ -S $socket ]]; then
+    local device command
+    device=auto
+    [[ -z $requested ]] || device="pipewire/$requested"
+    command=$(jq -cn --arg device "$device" '{command:["set_property","audio-device",$device]}')
+    if ! send_command "$command"; then
+      status >/dev/null
+      if [[ -S $socket ]]; then
+        echo 'Audio output could not be changed' >&2
+        exit 4
+      fi
+    fi
+  fi
+  status
 }
 
 source_stations() {
@@ -392,26 +462,34 @@ play_station() {
     fi
     mv "$temporary_queue" "$queue_file"
     mv "$temporary_playlist" "$playlist"
+    local -a player_arguments=(
+      mpv
+      --no-video
+      --force-window=no
+      --audio-display=no
+      --idle=yes
+      --loop-playlist=inf
+      --cache-secs=20
+      --demuxer-max-bytes=8MiB
+      --demuxer-max-back-bytes=2MiB
+      --network-timeout=30
+      --load-unsafe-playlists=no
+      --volume="$(configured_volume)"
+      --volume-max=100
+      --input-ipc-server="$socket"
+      --script="$status_script"
+      --playlist="$playlist"
+      --no-terminal
+      --really-quiet
+    )
+    local selected_output
+    selected_output=$(configured_output)
+    if [[ -n $selected_output ]]; then
+      player_arguments+=(--audio-device="pipewire/$selected_output")
+    fi
     RADIO_ATLAS_STATUS_FILE="$status_file" \
     RADIO_ATLAS_QUEUE_FILE="$queue_file" \
-    setsid "$script_dir/radio-session" mpv \
-      --no-video \
-      --force-window=no \
-      --audio-display=no \
-      --idle=yes \
-      --loop-playlist=inf \
-      --cache-secs=20 \
-      --demuxer-max-bytes=8MiB \
-      --demuxer-max-back-bytes=2MiB \
-      --network-timeout=30 \
-      --load-unsafe-playlists=no \
-      --volume="$(configured_volume)" \
-      --volume-max=100 \
-      --input-ipc-server="$socket" \
-      --script="$status_script" \
-      --playlist="$playlist" \
-      --no-terminal \
-      --really-quiet \
+    setsid "$script_dir/radio-session" "${player_arguments[@]}" \
       > "$log_file" 2>&1 8>&- &
     local player_pid=$!
     if ! write_player_pid "$player_pid"; then
@@ -475,6 +553,12 @@ case "$action" in
     ;;
   volume-down)
     adjust_volume -5
+    ;;
+  outputs)
+    list_outputs
+    ;;
+  output)
+    set_output "${2:-default}"
     ;;
   stop)
     stop_player

--- a/radio-player
+++ b/radio-player
@@ -300,17 +300,18 @@ list_outputs() {
     exit 3
   fi
   printf '%s' "$sinks" | jq -c '[
-    .[] | select(type == "object")
+    .[] | select(type == "object" and (.name | type == "string"))
+    | .name as $id
+    | select($id | test("^([A-Za-z0-9._:+-]{1,160})$"))
     | {
-        id: (.name | tostring | select(test("^([A-Za-z0-9._:+-]{1,160})$"))),
-        label: (if (.name | tostring | startswith("raop_sink."))
-          then ((.description // .name | tostring)
-            + " · " + (.name | tostring | split(".") | .[-5:-1] | join(".")))
-          else (.description // .name | tostring) end
+        id: $id,
+        label: (if ($id | startswith("raop_sink."))
+          then (((.description // $id) | tostring)
+            + " · " + ($id | split(".") | .[-5:-1] | join(".")))
+          else ((.description // $id) | tostring) end
           | gsub("[\\r\\n\\t]"; " ") | .[:160])
       }
-    | select(.id != null)
-  ][0:16] | {outputs: .}'
+  ] | {outputs: .}'
 }
 
 set_output() {
@@ -528,7 +529,7 @@ play_station() {
 }
 
 action=${1:-status}
-[[ $action == play ]] || flock -x 8
+[[ $action == play || $action == outputs ]] || flock -x 8
 case "$action" in
   play)
     play_station "${2:-}" "${3:-results}"

--- a/radio-player
+++ b/radio-player
@@ -317,7 +317,7 @@ refresh_saved_stations() {
   local source_file=$1
   local uuids refreshed
   uuids=$(jq -r 'map(.uuid) | join(",")' "$source_file")
-  [[ -n $uuids ]] || return
+  [[ -n $uuids ]] || return 0
 
   refreshed=$(mktemp "$runtime_dir/refreshed.XXXXXX")
   if "$fetch_path" resolve "$uuids" > "$refreshed"; then

--- a/radio-state
+++ b/radio-state
@@ -21,16 +21,19 @@ file_within_limit() {
 
 valid_state_file() {
   local path=$1
-  file_within_limit "$path" && jq -e -s '
-    length == 1 and (.[0]
-      | type == "object"
-      and (.favorites | type == "array")
-      and (.favorites | length <= 500)
-      and (.recent | type == "array")
-      and (.recent | length <= 30)
-      and ((.volume // 70) | type == "number")
-      and ((.volume // 70) >= 0 and (.volume // 70) <= 100))
-  ' "$path" >/dev/null 2>&1
+  [[ -s $path ]] && (( $(stat -c '%s' -- "$path") <= max_json_bytes )) \
+    && jq -e -s '
+      length == 1 and (.[0]
+        | type == "object"
+        and (.favorites | type == "array")
+        and (.favorites | length <= 500)
+        and (.recent | type == "array")
+        and (.recent | length <= 30)
+        and ((.volume // 70) | type == "number")
+        and ((.volume // 70) >= 0 and (.volume // 70) <= 100)
+        and ((.output // "") | type == "string")
+        and ((.output // "") | test("^([A-Za-z0-9._:+-]{0,160})$")))
+    ' "$path" >/dev/null 2>&1
 }
 
 ensure_state() {
@@ -103,6 +106,19 @@ write_volume() {
   mv "$temporary" "$state_file"
 }
 
+write_output() {
+  local output=$1
+  local temporary
+  temporary=$(mktemp "$state_dir/state.XXXXXX")
+  jq -c --arg output "$output" '.output = $output' "$state_file" > "$temporary"
+  if ! valid_state_file "$temporary"; then
+    rm -f "$temporary"
+    echo 'Radio Atlas could not save the audio output safely' >&2
+    return 4
+  fi
+  mv "$temporary" "$state_file"
+}
+
 ensure_state
 action=${1:-get}
 case "$action" in
@@ -136,6 +152,12 @@ case "$action" in
     (( volume >= 0 && volume <= 100 )) \
       || { echo 'Volume must be an integer from 0 to 100' >&2; exit 2; }
     write_volume "$volume"
+    ;;
+  output)
+    output=${2:-}
+    [[ $output =~ ^[A-Za-z0-9._:+-]{0,160}$ ]] \
+      || { echo 'Invalid audio output' >&2; exit 2; }
+    write_output "$output"
     ;;
   *)
     echo "Unknown action: $action" >&2

--- a/radio-state
+++ b/radio-state
@@ -21,8 +21,7 @@ file_within_limit() {
 
 valid_state_file() {
   local path=$1
-  [[ -s $path ]] && (( $(stat -c '%s' -- "$path") <= max_json_bytes )) \
-    && jq -e -s '
+  file_within_limit "$path" && jq -e -s '
       length == 1 and (.[0]
         | type == "object"
         and (.favorites | type == "array")

--- a/radio-status.lua
+++ b/radio-status.lua
@@ -25,8 +25,8 @@ end
 
 local function clean_output(value)
   if type(value) ~= "string" then return "" end
-  value = value:gsub("^pipewire/", "")
   if value == "auto" then return "" end
+  value = value:gsub("^pipewire/", "")
   return value:sub(1, 160)
 end
 

--- a/radio-status.lua
+++ b/radio-status.lua
@@ -6,6 +6,7 @@ local queue_path = os.getenv("RADIO_ATLAS_QUEUE_FILE")
 local queue = nil
 local update_timer = nil
 local last_volume = 70
+local last_output = ""
 local station_loaded = false
 local max_queue_bytes = 4194304
 
@@ -20,6 +21,13 @@ local function clean_text(value, limit)
     last = last - 1
   end
   return value:sub(1, last)
+end
+
+local function clean_output(value)
+  if type(value) ~= "string" then return "" end
+  value = value:gsub("^pipewire/", "")
+  if value == "auto" then return "" end
+  return value:sub(1, 160)
 end
 
 local function empty_station()
@@ -73,6 +81,7 @@ local function current_status()
   local position = mp.get_property_number("playlist-pos", -1)
   local volume = mp.get_property_number("volume", last_volume)
   last_volume = math.floor(volume + 0.5)
+  last_output = clean_output(mp.get_property("audio-device", ""))
   return {
     running = true,
     paused = mp.get_property_bool("pause", false),
@@ -81,6 +90,7 @@ local function current_status()
     playlistPosition = position,
     playlistCount = mp.get_property_number("playlist-count", 0),
     volume = last_volume,
+    output = last_output,
     loaded = station_loaded,
     station = status_station(read_queue()[position + 1])
   }
@@ -97,7 +107,7 @@ local function schedule_update()
 end
 
 for _, property in ipairs({
-  "pause", "mute", "media-title", "playlist-pos", "playlist-count", "volume"
+  "pause", "mute", "media-title", "playlist-pos", "playlist-count", "volume", "audio-device"
 }) do
   mp.observe_property(property, "native", schedule_update)
 end
@@ -132,6 +142,7 @@ mp.register_event("shutdown", function()
     playlistPosition = -1,
     playlistCount = 0,
     volume = last_volume,
+    output = last_output,
     loaded = false,
     station = empty_station()
   })

--- a/tests/fixtures/pactl
+++ b/tests/fixtures/pactl
@@ -16,5 +16,6 @@ if [[ $mode == many ]]; then
 fi
 printf '%s\n' '[
   {"name":"alsa_output.pci-0000_00_1f.3.analog-stereo","description":"Built-in Audio"},
-  {"name":"raop_sink.Living-Room.local.192.168.1.49.7000","description":"Living Room"}
+  {"name":"raop_sink.Living-Room.local.192.168.1.49.7000","description":"Living Room"},
+  {"name":"default","description":"Device named default"}
 ]'

--- a/tests/fixtures/pactl
+++ b/tests/fixtures/pactl
@@ -17,5 +17,6 @@ fi
 printf '%s\n' '[
   {"name":"alsa_output.pci-0000_00_1f.3.analog-stereo","description":"Built-in Audio"},
   {"name":"raop_sink.Living-Room.local.192.168.1.49.7000","description":"Living Room"},
-  {"name":"default","description":"Device named default"}
+  {"name":"default","description":"Device named default"},
+  {"name":"auto","description":"Device named auto"}
 ]'

--- a/tests/fixtures/pactl
+++ b/tests/fixtures/pactl
@@ -7,6 +7,13 @@ mode=${RADIO_ATLAS_TEST_PACTL_MODE:-}
 if [[ $mode == fail ]]; then
   exit 1
 fi
+if [[ $mode == many ]]; then
+  jq -cn '[range(1; 19) | {
+    name: ("test_sink_" + tostring),
+    description: ("Test Output " + tostring)
+  }]'
+  exit 0
+fi
 printf '%s\n' '[
   {"name":"alsa_output.pci-0000_00_1f.3.analog-stereo","description":"Built-in Audio"},
   {"name":"raop_sink.Living-Room.local.192.168.1.49.7000","description":"Living Room"}

--- a/tests/fixtures/pactl
+++ b/tests/fixtures/pactl
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode=${RADIO_ATLAS_TEST_PACTL_MODE:-}
+[[ -n $mode ]] || exec /usr/bin/pactl "$@"
+
+if [[ $mode == fail ]]; then
+  exit 1
+fi
+printf '%s\n' '[
+  {"name":"alsa_output.pci-0000_00_1f.3.analog-stereo","description":"Built-in Audio"},
+  {"name":"raop_sink.Living-Room.local.192.168.1.49.7000","description":"Living Room"}
+]'

--- a/tests/fixtures/socat
+++ b/tests/fixtures/socat
@@ -8,7 +8,19 @@ input=$(cat)
 if [[ $mode == success-unlink ]]; then
   rm -f "${RADIO_ATLAS_TEST_SOCKET:?}"
 fi
+device_file="${RADIO_ATLAS_TEST_SOCKET:-}.device"
+if [[ -n ${RADIO_ATLAS_TEST_SOCKET:-} ]]; then
+  requested=$(jq -r 'select(.command != null and .command[0] == "set_property"
+      and .command[1] == "audio-device") | .command[2] // empty' <<< "$input" 2>/dev/null || true)
+  if [[ -n $requested ]]; then
+    printf '%s' "$requested" > "$device_file"
+  fi
+fi
 if [[ $input == *'"request_id":1'* ]]; then
+  current_device="pipewire/raop_sink.Living-Room.local.192.168.1.49.7000"
+  if [[ -s $device_file ]]; then
+    current_device=$(<"$device_file")
+  fi
   printf '%s\n' \
     '{"data":false,"request_id":1,"error":"success"}' \
     '{"data":"Test Radio","request_id":2,"error":"success"}' \
@@ -16,6 +28,7 @@ if [[ $input == *'"request_id":1'* ]]; then
     '{"data":1,"request_id":4,"error":"success"}' \
     '{"data":70,"request_id":5,"error":"success"}' \
     '{"data":false,"request_id":6,"error":"success"}'
+  printf '{"data":"%s","request_id":7,"error":"success"}\n' "$current_device"
   exit 0
 fi
 

--- a/tests/run
+++ b/tests/run
@@ -6,7 +6,7 @@ project_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 jq -e '
   .schemaVersion == 1
   and .id == "akshar.radio-atlas"
-  and .version == "0.1.4"
+  and .version == "0.1.5"
   and (.kinds | index("overlay"))
   and (.kinds | index("bar-widget"))
   and .keepLoaded == true
@@ -102,6 +102,12 @@ sed -n '/id: mapHint/,/^          }/p' "$project_dir/RadioAtlas.qml" \
 rg -q 'rowMouse.containsMouse' "$project_dir/RadioAtlas.qml"
 ! rg -q 'selectedIndex === index.*Style.selectedFillFor' "$project_dir/RadioAtlas.qml"
 ! rg -q 'send_command .*\|\| true' "$project_dir/radio-player"
+rg -q 'id: outputMenu' "$project_dir/RadioAtlas.qml"
+rg -q 'function selectOutput' "$project_dir/RadioAtlas.qml"
+rg -q 'function toggleOutputMenu' "$project_dir/RadioAtlas.qml"
+rg -Fq '"audio-device",$device' "$project_dir/radio-player"
+rg -Fq 'set_property","audio-device' "$project_dir/radio-player"
+rg -q 'audio-device' "$project_dir/radio-status.lua"
 rg -q 'maximumLength: 128' "$project_dir/RadioAtlas.qml"
 rg -Fq 'Math.min(1.5, Math.max(0.7, globeRadius / 500))' "$project_dir/Globe.qml"
 rg -Fq 'estimatedLocation === true' "$project_dir/Globe.qml"
@@ -449,6 +455,11 @@ if "$project_dir/radio-player" volume 42 >/dev/null 2>&1; then
   echo "Volume update overwrote invalid saved state" >&2
   exit 1
 fi
+if RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output raop_sink.Living-Room.local.192.168.1.49.7000 >/dev/null 2>&1; then
+  echo "Output update overwrote invalid saved state" >&2
+  exit 1
+fi
 cmp "$test_root/invalid-state.json" "$XDG_DATA_HOME/radio-atlas/state.json"
 rm "$XDG_DATA_HOME/radio-atlas/state.json"
 
@@ -519,6 +530,45 @@ done
   | jq -e '.running == false and .volume == 81' >/dev/null
 jq -e '.volume == 81' "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
 
+if RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" outputs > "$test_root/outputs.json"; then
+  jq -e '(.outputs | length == 2)
+    and .outputs[0].id == "alsa_output.pci-0000_00_1f.3.analog-stereo"
+    and .outputs[0].label == "Built-in Audio"
+    and .outputs[1].id == "raop_sink.Living-Room.local.192.168.1.49.7000"
+    and .outputs[1].label == "Living Room · 192.168.1.49"' \
+    "$test_root/outputs.json" >/dev/null
+else
+  echo "Audio output listing failed" >&2
+  exit 1
+fi
+if RADIO_ATLAS_TEST_PACTL_MODE=fail PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" outputs >/dev/null 2>&1; then
+  echo "Missing audio server was reported as success" >&2
+  exit 1
+fi
+
+RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output raop_sink.Living-Room.local.192.168.1.49.7000 \
+  | jq -e '.running == false and .output == "raop_sink.Living-Room.local.192.168.1.49.7000"' >/dev/null
+jq -e '.output == "raop_sink.Living-Room.local.192.168.1.49.7000"' \
+  "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
+if RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output missing_sink >/dev/null 2>&1; then
+  echo "Unknown audio output was accepted" >&2
+  exit 1
+fi
+jq -e '.output == "raop_sink.Living-Room.local.192.168.1.49.7000"' \
+  "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
+RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output default \
+  | jq -e '.running == false and .output == ""' >/dev/null
+jq -e '(.output // "") == ""' "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
+if "$project_dir/radio-state" output 'bad sink!' >/dev/null 2>&1; then
+  echo "Invalid audio output name was saved" >&2
+  exit 1
+fi
+
 fetch_ready="$test_root/fetch-ready"
 fetch_release="$test_root/fetch-release"
 mpv_marker="$test_root/canceled-mpv-started"
@@ -554,6 +604,17 @@ for _ in $(seq 1 50); do
   sleep 0.02
 done
 [[ -S $runtime_dir/mpv.sock ]]
+
+RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
+  RADIO_ATLAS_TEST_SOCKET="$runtime_dir/mpv.sock" \
+  PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output raop_sink.Living-Room.local.192.168.1.49.7000 \
+  | jq -e '.running == true and .output == "raop_sink.Living-Room.local.192.168.1.49.7000"' >/dev/null
+RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
+  RADIO_ATLAS_TEST_SOCKET="$runtime_dir/mpv.sock" \
+  PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output default \
+  | jq -e '.running == true and .output == ""' >/dev/null
 
 if RADIO_ATLAS_TEST_SOCAT_MODE=error PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" toggle >/dev/null 2>&1; then

--- a/tests/run
+++ b/tests/run
@@ -107,6 +107,11 @@ rg -q 'function selectOutput' "$project_dir/RadioAtlas.qml"
 rg -q 'function toggleOutputMenu' "$project_dir/RadioAtlas.qml"
 rg -Fq '"audio-device",$device' "$project_dir/radio-player"
 rg -Fq 'set_property","audio-device' "$project_dir/radio-player"
+rg -q 'property string playerTitle: ""' "$project_dir/RadioAtlas.qml"
+sed -n '/function applyPlayerState/,/^  }/p' "$project_dir/RadioAtlas.qml" \
+  | rg -Fq 'playerTitle = String(state.title'
+[[ $(sed -n '/id: outputsProcess/,/^  }/p' "$project_dir/RadioAtlas.qml" \
+  | rg -c -F 'root.audioOutputs = []') == 2 ]]
 rg -q 'audio-device' "$project_dir/radio-status.lua"
 rg -q 'maximumLength: 128' "$project_dir/RadioAtlas.qml"
 rg -Fq 'Math.min(1.5, Math.max(0.7, globeRadius / 500))' "$project_dir/Globe.qml"
@@ -610,6 +615,15 @@ RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
   PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" output raop_sink.Living-Room.local.192.168.1.49.7000 \
   | jq -e '.running == true and .output == "raop_sink.Living-Room.local.192.168.1.49.7000"' >/dev/null
+if RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=error \
+  PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output alsa_output.pci-0000_00_1f.3.analog-stereo \
+  >/dev/null 2>&1; then
+  echo "Rejected audio output change was reported as success" >&2
+  exit 1
+fi
+jq -e '.output == "raop_sink.Living-Room.local.192.168.1.49.7000"' \
+  "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
 RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
   RADIO_ATLAS_TEST_SOCKET="$runtime_dir/mpv.sock" \
   PATH="$project_dir/tests/fixtures:$PATH" \

--- a/tests/run
+++ b/tests/run
@@ -109,6 +109,10 @@ rg -Fq '"audio-device",$device' "$project_dir/radio-player"
 rg -Fq 'set_property","audio-device' "$project_dir/radio-player"
 rg -q 'id: outputList' "$project_dir/RadioAtlas.qml"
 ! rg -Fq '.slice(0, 16)' "$project_dir/RadioAtlas.qml"
+sed -n '/tooltipText: root.playerOutput/,/^              }/p' "$project_dir/RadioAtlas.qml" \
+  | rg -q 'focusable: true'
+sed -n '/id: outputOption/,/^                }/p' "$project_dir/RadioAtlas.qml" \
+  | rg -q 'focusable: true'
 rg -q 'property string playerTitle: ""' "$project_dir/RadioAtlas.qml"
 sed -n '/function applyPlayerState/,/^  }/p' "$project_dir/RadioAtlas.qml" \
   | rg -Fq 'playerTitle = String(state.title'
@@ -539,11 +543,12 @@ jq -e '.volume == 81' "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
 
 if RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" outputs > "$test_root/outputs.json"; then
-  jq -e '(.outputs | length == 2)
+  jq -e '(.outputs | length == 3)
     and .outputs[0].id == "alsa_output.pci-0000_00_1f.3.analog-stereo"
     and .outputs[0].label == "Built-in Audio"
     and .outputs[1].id == "raop_sink.Living-Room.local.192.168.1.49.7000"
-    and .outputs[1].label == "Living Room · 192.168.1.49"' \
+    and .outputs[1].label == "Living Room · 192.168.1.49"
+    and .outputs[2].id == "default"' \
     "$test_root/outputs.json" >/dev/null
 else
   echo "Audio output listing failed" >&2
@@ -556,6 +561,9 @@ jq -e '(.outputs | length == 18) and .outputs[17].id == "test_sink_18"' \
 RADIO_ATLAS_TEST_PACTL_MODE=many PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" output test_sink_18 \
   | jq -e '.running == false and .output == "test_sink_18"' >/dev/null
+RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output default \
+  | jq -e '.running == false and .output == "default"' >/dev/null
 if RADIO_ATLAS_TEST_PACTL_MODE=fail PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" outputs >/dev/null 2>&1; then
   echo "Missing audio server was reported as success" >&2
@@ -575,7 +583,7 @@ fi
 jq -e '.output == "raop_sink.Living-Room.local.192.168.1.49.7000"' \
   "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
 RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
-  "$project_dir/radio-player" output default \
+  "$project_dir/radio-player" output \
   | jq -e '.running == false and .output == ""' >/dev/null
 jq -e '(.output // "") == ""' "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
 if "$project_dir/radio-state" output 'bad sink!' >/dev/null 2>&1; then
@@ -636,7 +644,7 @@ jq -e '.output == "raop_sink.Living-Room.local.192.168.1.49.7000"' \
 RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
   RADIO_ATLAS_TEST_SOCKET="$runtime_dir/mpv.sock" \
   PATH="$project_dir/tests/fixtures:$PATH" \
-  "$project_dir/radio-player" output default \
+  "$project_dir/radio-player" output \
   | jq -e '.running == true and .output == ""' >/dev/null
 
 if RADIO_ATLAS_TEST_SOCAT_MODE=error PATH="$project_dir/tests/fixtures:$PATH" \

--- a/tests/run
+++ b/tests/run
@@ -241,6 +241,14 @@ runtime_dir="$XDG_RUNTIME_DIR/omarchy-radio-atlas"
 cache_dir="$XDG_CACHE_HOME/omarchy-radio-atlas"
 mkdir -p "$runtime_dir"
 
+for device_and_output in "auto:" "pipewire/auto:auto"; do
+  RADIO_ATLAS_STATUS_FILE="$test_root/status.json" \
+  RADIO_ATLAS_QUEUE_FILE="$test_root/missing-queue.json" \
+  RADIO_ATLAS_TEST_AUDIO_DEVICE=${device_and_output%%:*} \
+  RADIO_ATLAS_TEST_EXPECTED_OUTPUT=${device_and_output#*:} \
+    lua "$project_dir/tests/status.test.lua" "$project_dir/radio-status.lua"
+done
+
 track_player_pid() {
   local pid=$1
   printf '%s %s\n' "$pid" "$(awk '{ print $22 }' "/proc/$pid/stat")" \
@@ -543,12 +551,13 @@ jq -e '.volume == 81' "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
 
 if RADIO_ATLAS_TEST_PACTL_MODE=json PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" outputs > "$test_root/outputs.json"; then
-  jq -e '(.outputs | length == 3)
+  jq -e '(.outputs | length == 4)
     and .outputs[0].id == "alsa_output.pci-0000_00_1f.3.analog-stereo"
     and .outputs[0].label == "Built-in Audio"
     and .outputs[1].id == "raop_sink.Living-Room.local.192.168.1.49.7000"
     and .outputs[1].label == "Living Room · 192.168.1.49"
-    and .outputs[2].id == "default"' \
+    and .outputs[2].id == "default"
+    and .outputs[3].id == "auto"' \
     "$test_root/outputs.json" >/dev/null
 else
   echo "Audio output listing failed" >&2
@@ -641,6 +650,11 @@ if RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=error \
 fi
 jq -e '.output == "raop_sink.Living-Room.local.192.168.1.49.7000"' \
   "$XDG_DATA_HOME/radio-atlas/state.json" >/dev/null
+RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
+  RADIO_ATLAS_TEST_SOCKET="$runtime_dir/mpv.sock" \
+  PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output auto \
+  | jq -e '.running == true and .output == "auto"' >/dev/null
 RADIO_ATLAS_TEST_PACTL_MODE=json RADIO_ATLAS_TEST_SOCAT_MODE=success \
   RADIO_ATLAS_TEST_SOCKET="$runtime_dir/mpv.sock" \
   PATH="$project_dir/tests/fixtures:$PATH" \

--- a/tests/run
+++ b/tests/run
@@ -107,6 +107,8 @@ rg -q 'function selectOutput' "$project_dir/RadioAtlas.qml"
 rg -q 'function toggleOutputMenu' "$project_dir/RadioAtlas.qml"
 rg -Fq '"audio-device",$device' "$project_dir/radio-player"
 rg -Fq 'set_property","audio-device' "$project_dir/radio-player"
+rg -q 'id: outputList' "$project_dir/RadioAtlas.qml"
+! rg -Fq '.slice(0, 16)' "$project_dir/RadioAtlas.qml"
 rg -q 'property string playerTitle: ""' "$project_dir/RadioAtlas.qml"
 sed -n '/function applyPlayerState/,/^  }/p' "$project_dir/RadioAtlas.qml" \
   | rg -Fq 'playerTitle = String(state.title'
@@ -547,6 +549,13 @@ else
   echo "Audio output listing failed" >&2
   exit 1
 fi
+RADIO_ATLAS_TEST_PACTL_MODE=many PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" outputs > "$test_root/many-outputs.json"
+jq -e '(.outputs | length == 18) and .outputs[17].id == "test_sink_18"' \
+  "$test_root/many-outputs.json" >/dev/null
+RADIO_ATLAS_TEST_PACTL_MODE=many PATH="$project_dir/tests/fixtures:$PATH" \
+  "$project_dir/radio-player" output test_sink_18 \
+  | jq -e '.running == false and .output == "test_sink_18"' >/dev/null
 if RADIO_ATLAS_TEST_PACTL_MODE=fail PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-player" outputs >/dev/null 2>&1; then
   echo "Missing audio server was reported as success" >&2

--- a/tests/status.test.lua
+++ b/tests/status.test.lua
@@ -1,0 +1,33 @@
+local audio_device = assert(os.getenv("RADIO_ATLAS_TEST_AUDIO_DEVICE"))
+local expected_output = assert(os.getenv("RADIO_ATLAS_TEST_EXPECTED_OUTPUT"))
+
+package.preload["mp"] = function()
+  return {
+    get_property = function(name, default)
+      if name == "audio-device" then return audio_device end
+      return default
+    end,
+    get_property_number = function(_, default) return default end,
+    get_property_bool = function(_, default) return default end,
+    add_timeout = function(_, callback)
+      callback()
+      return { kill = function() end }
+    end,
+    observe_property = function() end,
+    register_event = function() end,
+    register_script_message = function() end
+  }
+end
+
+package.preload["mp.utils"] = function()
+  return {
+    parse_json = function() return nil end,
+    format_json = function(state)
+      assert(state.output == expected_output,
+        string.format("expected output %q, got %q", expected_output, state.output))
+      return "{}"
+    end
+  }
+end
+
+dofile(assert(arg[1]))


### PR DESCRIPTION
## What

- `radio-player outputs` / `output [sink]`: list PipeWire sinks through `pactl -f json`, validate the choice, persist it in `state.json`, apply it live over the player socket (`set_property audio-device`) and to newly started players.
- `output` field in `status.json` (bash poller + Lua `audio-device` observer) so the UI reflects the active device.
- Speaker button next to the volume slider with an inline picker: "System default" plus every sink. RAOP sinks are labelled with their address (`Office · 192.168.1.23`) so same-named speakers stay distinguishable.
- README: AirPlay setup (`pipewire-zeroconf` + the raop-discover config fragment), the firewall prerequisite (ufw drops RAOP timing feedback on UDP 6001-6002, so sessions connect but speakers stay silent), and mDNS flap recovery.
- Tests: a `pactl` fixture (json/fail modes), a stateful `socat` fixture that honors `set_property audio-device`, and behavioral plus static assertions.

## Why this shape

mpv has no AirPlay output, and PipeWire's RAOP modules turn AirPlay speakers into ordinary sinks, so output routing is sink selection. That keeps the change small: no protocol code, no extra daemon, and the sandbox stays intact because the RAOP connection lives in the PipeWire daemon, outside the player's bubblewrap namespace. Per-device volume, encryption/transport options, and receiver mode are deliberately out of scope; those belong to the system layer.

## Drive-by fix (separate commit)

`refresh_saved_stations` returned the failing status of its `[[ -n $uuids ]]` guard on an empty favorites or recent list, so under `set -e` the player exited silently before reaching the missing-station check. Surfaced by the new tests.

## Testing

`./tests/run` green; qmllint reports no new warning categories. Verified live against HomePod, Apple TV, and Sonos speakers: switching mid-playback, fallback to the default output when a device disappears, and the firewall rule requirement reproduced before and after.
