### PR TITLE
Resume playback after the audio output device returns

### DIFF
--- a/radio-player
+++ b/radio-player
@@ -456,6 +456,9 @@ case "$action" in
     play_station "${2:-}" "${3:-results}"
     ;;
   toggle)
+    # Mark this as a deliberate pause so radio-status.lua does not mistake it
+    # for an audio device disappearing and auto-resume it.
+    send_command '{"command":["script-message","radio-atlas-user-pause"]}' || true
     player_command '{"command":["cycle","pause"]}'
     ;;
   next)

--- a/radio-status.lua
+++ b/radio-status.lua
@@ -96,8 +96,179 @@ local function schedule_update()
   update_timer = mp.add_timeout(0.04, emit_status)
 end
 
+-- ---------------------------------------------------------------------------
+-- Audio device recovery
+--
+-- When mpv's output device disappears (a USB interface unplugged, a dock
+-- detached) mpv sets pause=true and never resumes, even once the device is
+-- back. PipeWire reattaches the stream on its own; only mpv's paused flag is
+-- left behind, so playback stays silent until somebody presses play.
+--
+-- Two things make that awkward to correct automatically:
+--
+--   1. mpv does not report *why* it paused. During a device loss current-ao,
+--      audio-device, core-idle and eof-reached all read exactly as they do
+--      after a deliberate pause, so the reason cannot be recovered from state.
+--      radio-player therefore sends "radio-atlas-user-pause" before it toggles
+--      pause, and any pause without that marker is treated as device loss.
+--
+--   2. There is no dependable way to tell when a device is ready again.
+--      Enumeration takes anywhere from a moment to several seconds depending on
+--      port, hub and device, and under --audio-device=auto mpv never reveals
+--      which device it had resolved to, so a returning device cannot even be
+--      recognised by name. Rather than guess a delay, recovery is
+--      self-correcting: unpause and let mpv arbitrate. If the device is still
+--      unusable mpv pauses again within moments, and that bounce is what drives
+--      the backoff and retry below.
+-- ---------------------------------------------------------------------------
+
+local resume_settle_seconds = 1.0
+local resume_debounce_seconds = 0.2
+local max_resume_attempts = 8
+local max_backoff_seconds = 8
+
+local user_pause_pending = false
+local user_pause_timer = nil
+local device_lost = false
+local known_devices = nil
+local resume_timer = nil
+local resume_attempts = 0
+local resuming = false
+local settle_timer = nil
+local attempt_resume
+
+local function clear_user_pause_marker()
+  if user_pause_timer then user_pause_timer:kill() end
+  user_pause_timer = nil
+  user_pause_pending = false
+end
+
+-- radio-player announces a deliberate pause just before issuing it.
+mp.register_script_message("radio-atlas-user-pause", function()
+  if user_pause_timer then user_pause_timer:kill() end
+  user_pause_pending = true
+  -- The marker expires so a stale one cannot swallow a later device loss.
+  user_pause_timer = mp.add_timeout(2, clear_user_pause_marker)
+end)
+
+local function cancel_resume()
+  if resume_timer then resume_timer:kill() end
+  if settle_timer then settle_timer:kill() end
+  resume_timer = nil
+  settle_timer = nil
+  resuming = false
+end
+
+local function forget_device_loss()
+  device_lost = false
+  resume_attempts = 0
+  cancel_resume()
+end
+
+-- Spread retries out as attempts accumulate: 0.5s, 1s, 2s, 4s, then 8s.
+local function backoff_seconds()
+  local delay = 0.5 * 2 ^ math.max(resume_attempts - 1, 0)
+  if delay > max_backoff_seconds then delay = max_backoff_seconds end
+  return delay
+end
+
+local function schedule_resume(delay)
+  if resume_timer then resume_timer:kill() end
+  resume_timer = mp.add_timeout(delay, attempt_resume)
+end
+
+-- Unpause and wait to see whether it holds. Success is decided by silence: if
+-- mpv has not paused itself again once the settle window elapses, the device
+-- really is back.
+attempt_resume = function()
+  resume_timer = nil
+  if not device_lost then return end
+  if resume_attempts >= max_resume_attempts then
+    -- Out of attempts. Leave playback paused rather than retrying forever;
+    -- the user can press play once the device is sorted out.
+    forget_device_loss()
+    schedule_update()
+    return
+  end
+
+  resume_attempts = resume_attempts + 1
+  resuming = true
+  if settle_timer then settle_timer:kill() end
+  settle_timer = mp.add_timeout(resume_settle_seconds, function()
+    settle_timer = nil
+    if resuming then
+      resuming = false
+      forget_device_loss()
+      schedule_update()
+    end
+  end)
+  mp.set_property_bool("pause", false)
+end
+
+mp.observe_property("pause", "native", function(_, value)
+  if value == true then
+    if user_pause_pending then
+      -- Deliberate: radio-player told us this one was coming.
+      clear_user_pause_marker()
+      forget_device_loss()
+    elseif resuming then
+      -- Our unpause bounced straight back, so the device is not usable yet.
+      resuming = false
+      if settle_timer then settle_timer:kill() end
+      settle_timer = nil
+      schedule_resume(backoff_seconds())
+    else
+      -- Unmarked and unprompted: mpv lost its output device.
+      device_lost = true
+      resume_attempts = 0
+      cancel_resume()
+    end
+  elseif not resuming then
+    -- Playback restarted by something other than a retry (the user pressing
+    -- play, or a new station loading), so any pending recovery is moot.
+    clear_user_pause_marker()
+    forget_device_loss()
+  end
+  schedule_update()
+end)
+
+local function device_names(list)
+  local names = {}
+  if type(list) == "table" then
+    for _, device in ipairs(list) do
+      if type(device) == "table" and type(device.name) == "string" then
+        names[device.name] = true
+      end
+    end
+  end
+  return names
+end
+
+local function has_new_device(current, previous)
+  for name in pairs(current) do
+    if not previous[name] then return true end
+  end
+  return false
+end
+
+-- A device appearing is the cue to try again. Compared as a set rather than a
+-- count, so a swap that leaves the total unchanged still registers. The trigger
+-- does not have to be right: a premature attempt simply bounces and backs off.
+mp.observe_property("audio-device-list", "native", function(_, list)
+  local current = device_names(list)
+  local previous = known_devices
+  known_devices = current
+  if previous == nil then return end
+  if not device_lost then return end
+  if not has_new_device(current, previous) then return end
+
+  -- Fresh budget: something genuinely changed for the better.
+  resume_attempts = 0
+  schedule_resume(resume_debounce_seconds)
+end)
+
 for _, property in ipairs({
-  "pause", "mute", "media-title", "playlist-pos", "playlist-count", "volume"
+  "mute", "media-title", "playlist-pos", "playlist-count", "volume"
 }) do
   mp.observe_property(property, "native", schedule_update)
 end


### PR DESCRIPTION
Unplugging a USB audio interface and plugging it back in leaves the radio silent. The device is reselected, the stream is reattached to the correct sink, unmuted and at full volume — but mpv has set `pause=true` and never clears it, so nothing plays until you press play by hand.

This is mpv behaviour rather than anything PipeWire-specific. I reproduced it on a synthetic `module-null-sink` with no USB or ALSA involved: create a sink, play to it, destroy it, and mpv pauses within a second and stays paused through the device returning.

## Why it needs more than a resume call

**mpv does not report why it paused.** During a device loss `current-ao`, `audio-device`, `core-idle` and `eof-reached` all read exactly as they do after a deliberate pause, so the reason cannot be recovered from state. `radio-player` now sends a `radio-atlas-user-pause` script-message immediately before it toggles pause, and `radio-status.lua` treats any unmarked pause as device loss. The marker expires after two seconds so a stale one cannot swallow a later loss.

**There is no dependable way to know when a device is ready.** Enumeration takes anywhere from a moment to several seconds depending on port, hub and device, and under `--audio-device=auto` mpv never reveals which device it resolved to, so a returning device cannot be matched by name either.

So rather than guess a delay, recovery is self-correcting: unpause and let mpv arbitrate. If the device is still unusable mpv pauses again within moments, and that bounce drives an exponential backoff, bounded at eight attempts so a flapping device cannot thrash.

Resumes fire only when a device **appears**, compared as a set rather than a count so a swap that leaves the total unchanged still registers. A device merely going away never triggers one — that is what keeps playback from being resumed onto an unintended fallback output.

## Testing

Against a synthetic sink, plus the existing `./tests/run` suite:

| Scenario | Expected | Result |
| --- | --- | --- |
| Device lost, then returns | resumes unattended | passes, resumes ~1s after return |
| Deliberate pause, unrelated device appears | stays paused | passes |
| Device lost and never returns | stays paused, no thrash | passes, no resume onto fallback |
| Three consecutive loss/return cycles | recovers each time | passes |
| `./tests/run` | passes | passes |

Also running against a Focusrite Scarlett Solo 4th Gen on real unplug/replug.

I am happy to adjust the tuning constants or the marker approach if you would rather solve the intent problem a different way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback recovery when the selected output device becomes unavailable.
  * Automatically retries playback when an audio device returns, using controlled retry timing.
  * Preserves intentional user pauses without automatically resuming playback.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->