### PR TITLE
fix: keep the selected station when its stream fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install runtime tools
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap iproute2 jq lua5.4 python3 ripgrep socat
+          sudo apt-get install --yes bubblewrap iproute2 jq lua5.4 mpv python3 ripgrep socat
 
       - name: Allow Bubblewrap user namespaces
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -11,6 +11,7 @@ BarWidget {
 
   property bool playerRunning: false
   property bool playerPaused: false
+  property string streamError: ""
   property bool playerMuted: false
   property int playerVolume: 70
   property int reportedVolume: 70
@@ -34,6 +35,7 @@ BarWidget {
       var state = JSON.parse(raw || "{}")
       root.playerRunning = state.running === true
       root.playerPaused = state.paused === true
+      root.streamError = root.singleLineText(state.error || "", 200)
       root.playerMuted = state.muted === true
       var nextVolume = Math.round(Number(state.volume === undefined ? 70 : state.volume))
       root.reportedVolume = isFinite(nextVolume)
@@ -132,7 +134,8 @@ BarWidget {
     text: "\uf0ac"
     active: root.playerRunning && !root.playerPaused
     tooltipText: root.playerRunning
-      ? (root.playerPaused ? "Radio paused: " : "Playing: ") + root.safeTooltipText(root.playerTitle)
+      ? (root.streamError ? root.streamError + ": " : root.playerPaused ? "Radio paused: " : "Playing: ")
+        + root.safeTooltipText(root.playerTitle)
         + "  ·  " + (root.playerMuted ? "muted" : root.playerVolume + "%")
       : "Open Radio Atlas"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ usual play, pause, previous, and next controls.
 - Automatic dismissal when Omarchy starts its screensaver
 - Keyboard navigation
 - Persistent world and country caches with background refresh and transient retries
-- Automatic skip to the next playlist entry when a stream fails
+- Keeps your chosen station selected if its stream fails, with explicit retry or next controls
 
 ## Install
 
@@ -73,6 +73,13 @@ Favorites, listening history, volume, and the selected audio output remain in
 
 On the bar, left click opens Radio Atlas, middle click tunes randomly, right
 click stops its player, and the mouse wheel adjusts radio volume.
+
+If a station disconnects or cannot be played, Radio Atlas keeps it selected and
+shows the failure. Click the play button to retry that station, or Next/Previous
+to choose another queued station. It does not automatically reconnect or switch
+stations. A repeated opening clip can come from the station's stream server;
+retrying may play that same clip again. Radio Browser supplies station listings,
+not the audio streams.
 
 ## Audio outputs and AirPlay
 

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -41,6 +41,7 @@ Item {
 
   property bool playerRunning: false
   property bool playerPaused: false
+  property string streamError: ""
   property bool playerMuted: false
   property int playerVolume: 70
   property int reportedVolume: 70
@@ -540,6 +541,7 @@ Item {
       var nextPlayingUuid = nextPlayingStation ? String(nextPlayingStation.uuid) : ""
       playerRunning = state.running === true
       playerPaused = state.paused === true
+      streamError = String(state.error || "").replace(/[\r\n\t]+/g, " ").slice(0, 200)
       playerMuted = state.muted === true
       playerOutput = /^[A-Za-z0-9._:+-]{0,160}$/.test(String(state.output || ""))
         ? String(state.output) : ""
@@ -1722,12 +1724,13 @@ Item {
               anchors.topMargin: Style.spacing.xs
               text: root.playerError
                 ? root.playerError
+                : root.streamError ? root.streamError + ". Play to retry, or Next."
                 : (!root.playerRunning ? "Choose a signal to begin"
                 : (root.playingTrackTitle ? root.playingTrackTitle + "  ·  " : "")
                   + (root.playerPaused ? "Paused" : "Live")
                   + (root.playlistCount > 1 ? "  ·  " + root.playlistCount + " stations queued" : ""))
               textFormat: Text.PlainText
-              color: root.playerError ? root.urgent : root.dim
+              color: root.playerError || root.streamError ? root.urgent : root.dim
               font.family: Style.font.menuFamily
               font.pixelSize: Style.font.caption
               elide: Text.ElideRight
@@ -1771,7 +1774,8 @@ Item {
               }
               Button {
                 iconText: root.playerRunning && !root.playerPaused ? "\uf04c" : "\uf04b"
-                tooltipText: root.playerRunning && !root.playerPaused ? "Pause" : "Play"
+                tooltipText: root.streamError ? "Retry station"
+                  : root.playerRunning && !root.playerPaused ? "Pause" : "Play"
                 enabled: !root.playerActionBusy
                 focusable: true
                 foreground: root.foreground

--- a/radio-player
+++ b/radio-player
@@ -164,6 +164,7 @@ status() {
       '{"command":["get_property","volume"],"request_id":5}' \
       '{"command":["get_property","mute"],"request_id":6}' \
       '{"command":["get_property","audio-device"],"request_id":7}' \
+      '{"command":["get_property","user-data/radio-atlas-failure"],"request_id":8}' \
       | socat -T 1 - "UNIX-CONNECT:$socket" 2>/dev/null \
       | head -c "$((max_ipc_bytes + 1))" || true
   )
@@ -177,8 +178,14 @@ status() {
     return
   fi
 
-  local position station loaded station_uuid loaded_uuid
+  local position station loaded station_uuid loaded_uuid failure
+  failure=$(jq -sc '[.[] | select(.request_id == 8 and .error == "success") | .data
+    | select(type == "object" and (.position | type == "number")
+      and (.message | type == "string") and (.detail | type == "string"))][0] // null' <<< "$response")
   position=$(jq -r 'select(.request_id == 3) | .data' <<< "$response" | head -n 1)
+  if [[ $failure != null ]]; then
+    position=$(jq -r '.position' <<< "$failure")
+  fi
   station='{}'
   if [[ $position =~ ^[0-9]+$ ]] && valid_runtime_array "$queue_file"; then
     station=$(jq -c --argjson position "$position" '
@@ -201,18 +208,22 @@ status() {
     [[ $loaded_uuid == "$station_uuid" ]] && loaded=true
   fi
 
-  write_status "$(jq -sc --argjson station "$station" --argjson loaded "$loaded" '{
+  [[ $failure == null ]] || loaded=false
+  write_status "$(jq -sc --argjson station "$station" --argjson loaded "$loaded" \
+    --argjson failure "$failure" '{
     running: true,
-    paused: ([.[] | select(.request_id == 1) | .data][0] // false),
+    paused: ($failure != null or ([.[] | select(.request_id == 1) | .data][0] // false)),
     muted: ([.[] | select(.request_id == 6) | .data][0] // false),
     title: (([.[] | select(.request_id == 2) | .data][0] // "")
       | if type == "string" then gsub("[\\r\\n\\t]"; " ")[:512] else "" end),
-    playlistPosition: ([.[] | select(.request_id == 3) | .data][0] // -1),
+    playlistPosition: ($failure.position // [.[] | select(.request_id == 3) | .data][0] // -1),
     playlistCount: ([.[] | select(.request_id == 4) | .data][0] // 0),
     volume: ([.[] | select(.request_id == 5) | .data][0] // 70),
     output: (([.[] | select(.request_id == 7) | .data][0] // "")
       | if type == "string" then (if . == "auto" then "" else sub("^pipewire/"; "") end) else "" end),
     loaded: $loaded,
+    error: ($failure.message // ""),
+    errorDetail: ($failure.detail // ""),
     station: $station
   }' <<< "$response")"
 }
@@ -534,7 +545,7 @@ case "$action" in
     play_station "${2:-}" "${3:-results}"
     ;;
   toggle)
-    player_command '{"command":["cycle","pause"]}'
+    player_command '{"command":["script-message","radio-atlas-toggle"]}'
     ;;
   next)
     player_command '{"command":["playlist-next","force"]}'

--- a/radio-status.lua
+++ b/radio-status.lua
@@ -8,6 +8,8 @@ local update_timer = nil
 local last_volume = 70
 local last_output = ""
 local station_loaded = false
+local station_position = -1
+local failure = nil
 local max_queue_bytes = 4194304
 
 local function clean_text(value, limit)
@@ -78,13 +80,13 @@ local function write_status(state)
 end
 
 local function current_status()
-  local position = mp.get_property_number("playlist-pos", -1)
+  local position = failure and failure.position or mp.get_property_number("playlist-pos", -1)
   local volume = mp.get_property_number("volume", last_volume)
   last_volume = math.floor(volume + 0.5)
   last_output = clean_output(mp.get_property("audio-device", ""))
   return {
     running = true,
-    paused = mp.get_property_bool("pause", false),
+    paused = failure ~= nil or mp.get_property_bool("pause", false),
     muted = mp.get_property_bool("mute", false),
     title = clean_text(mp.get_property("media-title", ""), 512),
     playlistPosition = position,
@@ -92,6 +94,8 @@ local function current_status()
     volume = last_volume,
     output = last_output,
     loaded = station_loaded,
+    error = failure and failure.message or "",
+    errorDetail = failure and failure.detail or "",
     station = status_station(read_queue()[position + 1])
   }
 end
@@ -114,23 +118,49 @@ end
 
 mp.register_event("start-file", function()
   station_loaded = false
+  station_position = mp.get_property_number("playlist-pos", -1)
+  failure = nil
+  mp.set_property_native("user-data/radio-atlas-failure", nil)
   schedule_update()
 end)
 mp.register_event("file-loaded", function()
   station_loaded = true
   schedule_update()
 end)
-mp.register_event("end-file", function()
+mp.register_event("end-file", function(event)
+  if event.reason == "eof" or event.reason == "error" then
+    failure = {
+      position = station_position,
+      message = station_loaded and "Stream disconnected" or "Station could not be played",
+      detail = clean_text(event.error, 200)
+    }
+    mp.set_property_native("user-data/radio-atlas-failure", failure)
+  end
   station_loaded = false
   schedule_update()
 end)
+-- A hook blocks mpv from opening the next queued station before we stop it.
+mp.add_hook("on_after_end_file", 50, function()
+  if failure then mp.commandv("stop", "keep-playlist") end
+end)
 mp.register_event("idle", function()
   station_loaded = false
+  -- Retain native Next/Previous navigation without reopening the failed stream.
+  if failure then mp.set_property_number("playlist-current-pos", failure.position) end
   schedule_update()
 end)
 mp.register_script_message("radio-atlas-reload", function()
   queue = nil
   schedule_update()
+end)
+mp.register_script_message("radio-atlas-toggle", function()
+  if failure then
+    if failure.position < 0 then return end
+    mp.commandv("playlist-play-index", failure.position)
+    mp.set_property_bool("pause", false)
+    return
+  end
+  mp.commandv("cycle", "pause")
 end)
 mp.register_event("shutdown", function()
   if update_timer then update_timer:kill() end

--- a/tests/playback.test.py
+++ b/tests/playback.test.py
@@ -1,0 +1,145 @@
+"""Exercise stream failure and recovery with real mpv, without audio or public network."""
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+import wave
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+PROJECT = Path(__file__).resolve().parents[1]
+
+
+def audio(seconds):
+    data = io.BytesIO()
+    with wave.open(data, "wb") as stream:
+        stream.setnchannels(1)
+        stream.setsampwidth(2)
+        stream.setframerate(8000)
+        stream.writeframes(b"\0\0" * int(8000 * seconds))
+    return data.getvalue()
+
+
+class PlaybackTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory(prefix="radio-atlas-playback-")
+        self.addCleanup(self.directory.cleanup)
+        root = Path(self.directory.name)
+        runtime = root / "omarchy-radio-atlas"
+        runtime.mkdir()
+        self.status_path = runtime / "status.json"
+        self.requests = []
+        requests = self.requests
+        short, live = audio(0.2), audio(30)
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                requests.append(self.path)
+                if self.path == "/broken":
+                    self.send_error(503)
+                    return
+                data = short if self.path == "/short" else live
+                self.send_response(200)
+                self.send_header("Content-Type", "audio/wav")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                try:
+                    self.wfile.write(data)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+            def log_message(self, *_):
+                pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.addCleanup(self.server.server_close)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.addCleanup(self.server.shutdown)
+        self.env = dict(os.environ, XDG_RUNTIME_DIR=str(root), XDG_DATA_HOME=str(root / "data"),
+                        RADIO_ATLAS_STATUS_FILE=str(self.status_path),
+                        RADIO_ATLAS_QUEUE_FILE=str(runtime / "playlist.json"))
+        self.runtime = runtime
+
+    def start(self, paths, position=0):
+        urls = [f"http://127.0.0.1:{self.server.server_port}{path}" for path in paths]
+        queue = [dict(uuid=f"station-{i}", name=path, url=url)
+                 for i, (path, url) in enumerate(zip(paths, urls))]
+        (self.runtime / "playlist.json").write_text(json.dumps(queue))
+        self.log = tempfile.TemporaryFile(mode="w+")
+        self.addCleanup(self.log.close)
+        process = subprocess.Popen([
+            "mpv", "--no-config", "--no-video", "--ao=null", "--idle=yes",
+            "--loop-playlist=inf", "--network-timeout=2", f"--playlist-start={position}",
+            f"--script={PROJECT / 'radio-status.lua'}",
+            f"--input-ipc-server={self.runtime / 'mpv.sock'}", *urls,
+        ], env=self.env, stdout=self.log, stderr=self.log)
+
+        def stop():
+            process.terminate()
+            process.wait(timeout=5)
+
+        self.addCleanup(stop)
+
+    def wait_status(self, predicate):
+        deadline = time.monotonic() + 6
+        state = {}
+        while time.monotonic() < deadline:
+            if self.status_path.exists():
+                state = json.loads(self.status_path.read_text())
+                if predicate(state):
+                    return state
+            time.sleep(0.02)
+        self.log.seek(0)
+        self.fail(f"Status did not match: {state}\n{self.log.read()}")
+
+    def action(self, action):
+        result = subprocess.run([str(PROJECT / "radio-player"), action], env=self.env,
+                                capture_output=True, text=True, timeout=5)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)
+
+    def test_disconnect_stays_selected_and_retry_reopens_same_stream(self):
+        self.start(["/short", "/live"])
+        state = self.wait_status(lambda s: s.get("error") == "Stream disconnected")
+        self.assertEqual(state["station"]["uuid"], "station-0")
+        self.assertFalse(state["loaded"])
+        self.assertTrue(state["paused"])
+        # Check the public status command too: it must not erase the Lua failure state.
+        self.assertEqual(self.action("status")["error"], "Stream disconnected")
+        self.assertEqual(self.requests, ["/short"])
+        self.action("toggle")
+        self.wait_status(lambda s: s.get("error") == "Stream disconnected")
+        self.assertEqual(self.requests, ["/short", "/short"])
+        self.action("next")
+        state = self.wait_status(lambda s: s.get("loaded") and s["station"]["uuid"] == "station-1")
+        self.assertEqual(state["error"], "")
+        self.assertFalse(state["paused"])
+        self.action("toggle")
+        self.wait_status(lambda s: s["paused"])
+        self.action("toggle")
+        self.wait_status(lambda s: not s["paused"])
+
+    def test_open_failure_stays_selected_and_previous_uses_failed_position(self):
+        self.start(["/live", "/broken", "/other"], position=1)
+        state = self.wait_status(lambda s: s.get("error") == "Station could not be played")
+        self.assertEqual(state["playlistPosition"], 1)
+        self.assertTrue(state["errorDetail"])
+        state = self.action("status")
+        self.assertEqual(state["station"]["uuid"], "station-1")
+        self.assertTrue(self.requests)
+        self.assertEqual(set(self.requests), {"/broken"})
+        failed_requests = list(self.requests)
+        self.action("status")
+        self.assertEqual(self.requests, failed_requests)
+        self.action("previous")
+        self.wait_status(lambda s: s.get("loaded") and s["playlistPosition"] == 0)
+        self.assertEqual(self.requests, failed_requests + ["/live"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/run
+++ b/tests/run
@@ -19,6 +19,7 @@ bash -n "$project_dir/radio-fetch" "$project_dir/radio-player" \
 luac -p "$project_dir/radio-status.lua"
 node "$project_dir/tests/model.test.mjs"
 python3 "$project_dir/tests/proxy.test.py"
+python3 "$project_dir/tests/playback.test.py"
 ! rg -q 'playerStatusProcess|refreshPlayerStatus' \
   "$project_dir/BarWidget.qml" "$project_dir/RadioAtlas.qml"
 rg -q 'maximumScale: 24' "$project_dir/Globe.qml"

--- a/tests/status.test.lua
+++ b/tests/status.test.lua
@@ -14,6 +14,7 @@ package.preload["mp"] = function()
       return { kill = function() end }
     end,
     observe_property = function() end,
+    add_hook = function() end,
     register_event = function() end,
     register_script_message = function() end
   }


### PR DESCRIPTION
Radio Atlas silently switched stations when a stream disconnected or failed to open. A listener could hear the same opening clip each time and then land on an unrelated station.

Keep the failed station selected and show the failure. Play explicitly retries it; Next and Previous remain native mpv playlist controls. Do not automatically reconnect. Preserve the failure through status refreshes and expose the player error detail for diagnosis.

The stream timeout reproduced outside Radio Atlas, so this fixes our response to the failure without claiming to repair the station server or network.

Closes #6.

Verification:
- Real mpv tests against a local HTTP server: end of stream, HTTP failure, no automatic advance, same-station retry, next/previous, pause/resume, and status refresh.
- Full ./tests/run suite passed.
- qmllint and omarchy plugin validate passed.
- Updated playback documentation.