### PR TITLE
perf: avoid unnecessary globe drawing and cached-list DNS lookups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes bubblewrap iproute2 jq lua5.4 mpv python3 ripgrep socat
+          sudo apt-get install --yes qt6-declarative-dev-tools qml6-module-qttest \
+            qml6-module-qtquick qml6-module-qtquick-window qml6-module-qtqml-workerscript \
+            qml6-module-qtqml-models
 
       - name: Allow Bubblewrap user namespaces
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/Globe.qml
+++ b/Globe.qml
@@ -7,6 +7,8 @@ Item {
   property var countries: []
   property var stations: []
   property var selectedStation: null
+  readonly property string selectedStationUuid: selectedStation ? String(selectedStation.uuid || "") : ""
+  readonly property real stationHitRadius: 12
   property string activeCountryCode: ""
 
   property real centreLatitude: 18
@@ -400,6 +402,11 @@ Item {
       row.screenX = globeCanvas.width / 2 + xProjection * globeRadius
       row.screenY = globeCanvas.height / 2 - yProjection * globeRadius
       row.depth = depth
+      row.visible = row.screenX >= -stationHitRadius
+        && row.screenX <= globeCanvas.width + stationHitRadius
+        && row.screenY >= -stationHitRadius
+        && row.screenY <= globeCanvas.height + stationHitRadius
+      if (!row.visible) continue
 
       var selected = selectedStation && row.station.uuid === selectedStation.uuid
       var highlighted = highlightedStation
@@ -460,7 +467,7 @@ Item {
 
   function stationUnderPointer(x, y) {
     var nearest = null
-    var nearestDistance = 144
+    var nearestDistance = stationHitRadius * stationHitRadius
     for (var i = 0; i < preparedStations.length; i++) {
       var row = preparedStations[i]
       if (!row.visible) continue
@@ -504,7 +511,7 @@ Item {
     refreshLandingHighlight()
     globeCanvas.requestPaint()
   }
-  onSelectedStationChanged: {
+  onSelectedStationUuidChanged: {
     clearLandingHighlight()
     globeCanvas.requestPaint()
   }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ stations. A repeated opening clip can come from the station's stream server;
 retrying may play that same clip again. Radio Browser supplies station listings,
 not the audio streams.
 
+Fresh world and country caches load without DNS lookups. The globe skips
+off-screen station markers when zoomed in, and player-status updates for the
+same station preserve the landing highlight without repainting the globe.
+
 ## Audio outputs and AirPlay
 
 The speaker button next to the volume slider chooses where radio plays. It lists

--- a/radio-fetch
+++ b/radio-fetch
@@ -22,6 +22,7 @@ country_cache_minutes=1440
 search_dir=""
 world_more_response=""
 world_more_result=""
+bases=()
 
 cleanup() {
   [[ -z $search_dir ]] || rm -rf "$search_dir"
@@ -42,10 +43,13 @@ discover_bases() {
 
 }
 
-mapfile -t bases < <(discover_bases | awk '!seen[$0]++' | shuf)
-if (( ${#bases[@]} == 0 )); then
-  bases=('https://all.api.radio-browser.info')
-fi
+load_bases() {
+  (( ${#bases[@]} > 0 )) && return
+  mapfile -t bases < <(discover_bases | awk '!seen[$0]++' | shuf)
+  if (( ${#bases[@]} == 0 )); then
+    bases=('https://all.api.radio-browser.info')
+  fi
+}
 
 normalize='def number_or_null: try tonumber catch null;
   def clean($limit):
@@ -91,6 +95,7 @@ request() {
   local max_records=$1
   local path=$2
   shift 2
+  load_bases
   local base error_file max_time response_file
   max_time=12
   (( max_records >= 500 )) && max_time=45
@@ -309,6 +314,7 @@ fetch_world() {
 
 fetch_search() {
   local query=$1
+  load_bases
   search_dir=$(mktemp -d "$runtime_dir/search.XXXXXX")
 
   request 80 '/json/stations/search' \

--- a/tests/fixtures/getent
+++ b/tests/fixtures/getent
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+[[ -z ${RADIO_ATLAS_TEST_DNS_LOG:-} ]] || printf '%s\n' "$*" >> "$RADIO_ATLAS_TEST_DNS_LOG"
 
 case ${1:-} in
   ahostsv4)

--- a/tests/qml/tst_globe.qml
+++ b/tests/qml/tst_globe.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import QtTest
+import "../.." as Atlas
+
+TestCase {
+  name: "Globe"
+  when: windowShown
+  width: 800
+  height: 600
+
+  Atlas.Globe {
+    id: globe
+    width: 800
+    height: 600
+  }
+
+  SignalSpy {
+    id: selectionChanges
+    target: globe
+    signalName: "selectedStationUuidChanged"
+  }
+
+  function init() {
+    globe.centreLatitude = 0
+    globe.centreLongitude = 0
+    globe.globeScale = 1
+    globe.stations = []
+    globe.selectedStation = null
+    globe.highlightedStation = null
+    selectionChanges.clear()
+  }
+
+  function test_statusUpdatePreservesLandingHighlight() {
+    globe.selectedStation = { uuid: "playing", name: "Radio", latitude: 0, longitude: 0 }
+    globe.highlightedStation = { uuid: "landing", latitude: 0, longitude: 5 }
+    selectionChanges.clear()
+
+    globe.selectedStation = { uuid: "playing", name: "Updated metadata", latitude: 0, longitude: 0 }
+    compare(selectionChanges.count, 0)
+    compare(globe.highlightedStation.uuid, "landing")
+
+    globe.selectedStation = { uuid: "different", latitude: 0, longitude: 10 }
+    compare(selectionChanges.count, 1)
+    compare(globe.highlightedStation, null)
+  }
+
+  function test_offscreenMarkersAreSkippedButEdgeMarkersRemainClickable() {
+    globe.globeScale = 3
+    var edgeLongitude = Math.asin((-6 - globe.width / 2) / globe.radius()) * 180 / Math.PI
+    var edge = { uuid: "edge", latitude: 0, longitude: edgeLongitude }
+    globe.stations = [
+      { uuid: "centre", latitude: 0, longitude: 0 },
+      { uuid: "offscreen", latitude: 0, longitude: 60 },
+      { uuid: "back", latitude: 0, longitude: 180 },
+      edge
+    ]
+    globe.selectedStation = edge
+    var arcs = []
+    var context = {
+      beginPath: function() {},
+      arc: function(x, y, radius) { arcs.push({ x: x, y: y, radius: radius }) },
+      fill: function() {},
+      stroke: function() {}
+    }
+    globe.paintSignals(context)
+    compare(arcs.length, 3)
+    compare(arcs[2].radius, 8.5)
+    compare(globe.stationUnderPointer(0, globe.height / 2).uuid, "edge")
+    compare(globe.stationUnderPointer(globe.width / 2, globe.height / 2).uuid, "centre")
+
+    globe.centreLongitude = 180
+    globe.paintSignals(context)
+    compare(globe.stationUnderPointer(globe.width / 2, globe.height / 2).uuid, "back")
+  }
+}

--- a/tests/run
+++ b/tests/run
@@ -20,6 +20,8 @@ luac -p "$project_dir/radio-status.lua"
 node "$project_dir/tests/model.test.mjs"
 python3 "$project_dir/tests/proxy.test.py"
 python3 "$project_dir/tests/playback.test.py"
+QT_QUICK_BACKEND=software /usr/lib/qt6/bin/qmltestrunner \
+  -platform offscreen -input "$project_dir/tests/qml"
 ! rg -q 'playerStatusProcess|refreshPlayerStatus' \
   "$project_dir/BarWidget.qml" "$project_dir/RadioAtlas.qml"
 rg -q 'maximumScale: 24' "$project_dir/Globe.qml"
@@ -292,8 +294,10 @@ if env -u XDG_RUNTIME_DIR "$project_dir/radio-state" get >/dev/null 2>&1; then
   exit 1
 fi
 
-PATH="$project_dir/tests/fixtures:$PATH" "$project_dir/radio-fetch" country US \
+RADIO_ATLAS_TEST_DNS_LOG="$test_root/network-dns.log" \
+  PATH="$project_dir/tests/fixtures:$PATH" "$project_dir/radio-fetch" country US \
   > "$test_root/normalized.json"
+[[ $(rg -c '^ahostsv4 ' "$test_root/network-dns.log") == 1 ]]
 jq -e '
   length == 1
   and .[0].uuid == "bbbbbbbb-1111-1111-1111-bbbbbbbbbbbb"
@@ -326,14 +330,18 @@ jq -e 'length == 1 and .[0].name == "First"' \
 jq -e 'length == 1 and .[0].name == "Old country cache"' \
   "$runtime_dir/results.json" >/dev/null
 
-RADIO_ATLAS_TEST_CURL_FAIL=1 PATH="$project_dir/tests/fixtures:$PATH" \
+RADIO_ATLAS_TEST_DNS_LOG="$test_root/cached-country-dns.log" \
+  RADIO_ATLAS_TEST_CURL_FAIL=1 PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-fetch" country US > "$test_root/cached-country.json"
 jq -e 'length == 1' "$test_root/cached-country.json" >/dev/null
+[[ ! -e "$test_root/cached-country-dns.log" ]]
 
 legacy_world='[{"uuid":"cccccccc-1111-1111-1111-cccccccccccc","name":"Cached","url":"https://example.com/cached","country":"Canada","countryCode":"CA","latitude":43,"longitude":-79}]'
 printf '%s\n' "$legacy_world" > "$runtime_dir/world.json"
-RADIO_ATLAS_TEST_CURL_FAIL=1 PATH="$project_dir/tests/fixtures:$PATH" \
+RADIO_ATLAS_TEST_DNS_LOG="$test_root/cached-world-dns.log" \
+  RADIO_ATLAS_TEST_CURL_FAIL=1 PATH="$project_dir/tests/fixtures:$PATH" \
   "$project_dir/radio-fetch" world > "$test_root/imported-world.json"
+[[ ! -e "$test_root/cached-world-dns.log" ]]
 jq -e 'length == 1 and .[0].name == "Cached"' "$test_root/imported-world.json" >/dev/null
 cmp "$test_root/imported-world.json" "$cache_dir/world.json"
 
@@ -421,8 +429,10 @@ if RADIO_ATLAS_TEST_CURL_MULTIPLE=always PATH="$project_dir/tests/fixtures:$PATH
   exit 1
 fi
 
-PATH="$project_dir/tests/fixtures:$PATH" "$project_dir/radio-fetch" search 93 \
+RADIO_ATLAS_TEST_DNS_LOG="$test_root/search-dns.log" \
+  PATH="$project_dir/tests/fixtures:$PATH" "$project_dir/radio-fetch" search 93 \
   > "$test_root/search.json"
+[[ $(rg -c '^ahostsv4 ' "$test_root/search-dns.log") == 1 ]]
 jq -e 'length == 2' "$test_root/search.json" >/dev/null
 
 if RADIO_ATLAS_TEST_CURL_FAIL=1 PATH="$project_dir/tests/fixtures:$PATH" \


### PR DESCRIPTION
Volume and metadata updates could clear the globe landing highlight even when the station had not changed. Zoomed views also drew off-screen markers, and cached station lists waited for unnecessary DNS discovery.

Track station identity by UUID, skip markers outside the viewport while preserving edge hit targets, and discover API servers only when making a request. Search still shares a single discovery across its three parallel requests.

Verified with real QML tests, DNS-call assertions for cache reads and search, the full test suite, qmllint, and plugin validation. Documentation updated. This removes measured unnecessary work; no frame-rate gain is claimed.