### PR TITLE
fix: refresh globe themes and stop fruitless station polling

### DIFF
--- a/Globe.qml
+++ b/Globe.qml
@@ -516,6 +516,13 @@ Item {
     globeCanvas.requestPaint()
   }
   onActiveCountryCodeChanged: globeCanvas.requestPaint()
+  onBackgroundColorChanged: globeCanvas.requestPaint()
+  onSphereColorChanged: globeCanvas.requestPaint()
+  onLandColorChanged: globeCanvas.requestPaint()
+  onGridColorChanged: globeCanvas.requestPaint()
+  onOutlineColorChanged: globeCanvas.requestPaint()
+  onSignalColorChanged: globeCanvas.requestPaint()
+  onAccentColorChanged: globeCanvas.requestPaint()
   onCentreLatitudeChanged: {
     updateHighlightPosition()
     globeCanvas.requestPaint()

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ not the audio streams.
 Fresh world and country caches load without DNS lookups. The globe skips
 off-screen station markers when zoomed in, and player-status updates for the
 same station preserve the landing highlight without repainting the globe.
+Theme colors update the globe immediately. Background station expansion stops
+after three consecutive attempts add no stations, including failed requests;
+reopening Radio Atlas allows expansion to try again.
 
 ## Audio outputs and AirPlay
 
@@ -145,9 +148,15 @@ Map geometry comes from public-domain Natural Earth data.
 ## Troubleshooting
 
 Player and proxy diagnostics are written to
-`$XDG_RUNTIME_DIR/omarchy-radio-atlas/mpv.log` and `proxy.log`. If saved state
-is malformed, oversized, or contains too many entries, Radio Atlas refuses to
-overwrite it and reports
+`$XDG_RUNTIME_DIR/omarchy-radio-atlas/mpv.log` and `proxy.log`. Proxy diagnostics
+identify request, connection, and relay failures, idle timeouts, and which side
+closed a connection. They omit URLs, hostnames, and raw error messages and are
+capped at 200 lines per player session. Stopping and starting playback begins
+a new session and replaces those logs. A connection closing is not necessarily
+an error; it also happens when changing stations or stopping playback.
+
+If saved state is malformed, oversized, or contains too many entries, Radio Atlas
+refuses to overwrite it and reports
 `~/.local/share/radio-atlas/state.json`; back up that file before repairing or
 removing it.
 

--- a/RadioAtlas.qml
+++ b/RadioAtlas.qml
@@ -38,6 +38,7 @@ Item {
   property string fetchStderr: ""
   property string worldExpandOutput: ""
   readonly property int worldStationLimit: 5000
+  property int worldExpansionMisses: 0
 
   property bool playerRunning: false
   property bool playerPaused: false
@@ -188,6 +189,7 @@ Item {
     try { payload = JSON.parse(payloadJson || "{}") } catch (error) { payload = ({}) }
 
     opened = true
+    worldExpansionMisses = 0
     windowFrameReady = false
     windowRevealTimer.stop()
     panel.visible = true
@@ -299,7 +301,7 @@ Item {
 
   function scheduleWorldExpansion(delay) {
     if (!opened || worldStations.length === 0
-        || worldStations.length >= worldStationLimit) return
+        || worldStations.length >= worldStationLimit || worldExpansionMisses >= 3) return
     worldExpandTimer.interval = Math.max(500, Number(delay || 1600))
     worldExpandTimer.restart()
   }
@@ -905,6 +907,7 @@ Item {
       var output = root.worldExpandOutput
       root.worldExpandOutput = ""
       if (!root.opened) return
+      root.worldExpansionMisses += 1
       if (exitCode !== 0) {
         root.scheduleWorldExpansion(30000)
         return
@@ -925,9 +928,14 @@ Item {
       var merged = RadioModel.mergeStations(
         root.worldStations, stations, root.worldStationLimit)
       var added = merged.length - root.worldStations.length
+      if (added === 0) {
+        root.scheduleWorldExpansion(10000)
+        return
+      }
+      root.worldExpansionMisses = 0
       root.worldStations = merged
       if (root.mode === "world") root.results = merged
-      root.scheduleWorldExpansion(added > 0 ? 1600 : 10000)
+      root.scheduleWorldExpansion(1600)
     }
   }
 

--- a/radio-player
+++ b/radio-player
@@ -209,7 +209,7 @@ status() {
   fi
 
   [[ $failure == null ]] || loaded=false
-  write_status "$(jq -sc --argjson station "$station" --argjson loaded "$loaded" \
+  printf '%s\n' "$(jq -sc --argjson station "$station" --argjson loaded "$loaded" \
     --argjson failure "$failure" '{
     running: true,
     paused: ($failure != null or ([.[] | select(.request_id == 1) | .data][0] // false)),

--- a/radio-proxy
+++ b/radio-proxy
@@ -16,6 +16,9 @@ from urllib.parse import urlsplit
 MAX_HEADER_BYTES = 65_536
 MAX_ACTIVE_CONNECTIONS = 32
 MAX_RESOLVED_ENDPOINTS = 16
+MAX_DIAGNOSTICS = 200
+diagnostic_count = 0
+diagnostic_lock = threading.Lock()
 NAT64_WELL_KNOWN = ipaddress.ip_network("64:ff9b::/96")
 IPV4_COMPATIBLE = ipaddress.ip_network("::/96")
 
@@ -23,6 +26,28 @@ IPV4_COMPATIBLE = ipaddress.ip_network("::/96")
 class ProxyError(Exception):
     def __init__(self, status: bytes):
         self.status = status
+
+
+def log_connection(stage, outcome, error=None):
+    global diagnostic_count
+    with diagnostic_lock:
+        if diagnostic_count >= MAX_DIAGNOSTICS:
+            return
+        diagnostic_count += 1
+        if diagnostic_count == MAX_DIAGNOSTICS:
+            print("radio-proxy: diagnostic limit reached for this session", file=sys.stderr, flush=True)
+            return
+        details = f"stage={stage} outcome={outcome}"
+        if error is not None:
+            details += f" error={type(error).__name__}"
+            if isinstance(error, ProxyError):
+                details += f" status={error.status[:3].decode('ascii')}"
+            cause = error.__cause__ or error
+            if cause is not error:
+                details += f" cause={type(cause).__name__}"
+            if isinstance(cause, OSError) and cause.errno is not None:
+                details += f" errno={cause.errno}"
+        print(f"radio-proxy: {details}", file=sys.stderr, flush=True)
 
 
 def embeds_non_public_ipv4(ip: ipaddress.IPv4Address | ipaddress.IPv6Address):
@@ -202,35 +227,39 @@ def relay(left: socket.socket, right: socket.socket):
     while True:
         readable, _, _ = select.select((left, right), (), (), 60)
         if not readable:
-            return
+            return "idle_timeout"
         for source in readable:
             data = source.recv(65_536)
             if not data:
-                return
+                return "client_closed" if source is left else "upstream_closed"
             (right if source is left else left).sendall(data)
 
 
 class ProxyHandler(socketserver.BaseRequestHandler):
     def handle(self):
         self.request.settimeout(12)
+        stage = "request"
         try:
             header, pending = read_header(self.request)
             method, host, port, forwarded = parse_request(header)
+            stage = "connect"
             with connect_public(host, port) as upstream:
+                stage = "relay"
                 if method == "CONNECT":
                     self.request.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
                 else:
                     upstream.sendall(forwarded)
                 if pending:
                     upstream.sendall(pending)
-                relay(self.request, upstream)
+                log_connection(stage, relay(self.request, upstream))
         except ProxyError as error:
+            log_connection(stage, "rejected", error)
             try:
                 self.request.sendall(b"HTTP/1.1 " + error.status + b"\r\nConnection: close\r\n\r\n")
             except OSError:
                 return
-        except (BrokenPipeError, ConnectionError, OSError, TimeoutError):
-            return
+        except OSError as error:
+            log_connection(stage, "failed", error)
 
 
 class ProxyServer(socketserver.ThreadingUnixStreamServer):

--- a/tests/expansion.test.mjs
+++ b/tests/expansion.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import vm from "node:vm"
+
+const source = fs.readFileSync(new URL("../RadioAtlas.qml", import.meta.url), "utf8")
+const schedule = source.match(/function scheduleWorldExpansion\(delay\) \{([\s\S]*?)\n  \}/)[1]
+const complete = source.match(/id: worldExpandProcess[\s\S]*?onExited: function\(exitCode\) \{([\s\S]*?)\n    \}\n  \}/)[1]
+const open = source.match(/function openWindow\(payloadJson\) \{([\s\S]*?)\n  \}/)[1]
+const model = vm.createContext({})
+vm.runInContext(fs.readFileSync(new URL("../RadioModel.js", import.meta.url), "utf8"), model)
+
+function session() {
+  const delays = []
+  const context = vm.createContext({
+    opened: true,
+    worldStationLimit: 5000,
+    worldExpansionMisses: 0,
+    worldStations: [{ uuid: "first" }],
+    mode: "world",
+    RadioModel: model,
+    panel: {},
+    windowRevealTimer: { stop() {} },
+    loadState() {},
+    Qt: { callLater() {} },
+    worldExpandTimer: { interval: 0, restart() { delays.push(this.interval) } },
+  })
+  context.root = context
+  vm.runInContext(`function scheduleWorldExpansion(delay) {${schedule}}
+    function complete(exitCode) {${complete}}
+    function openWindow(payloadJson) {${open}}`, context)
+  return {
+    context,
+    delays,
+    finish(rows, exitCode = 0) {
+      context.worldExpandOutput = JSON.stringify(rows)
+      context.complete(exitCode)
+    },
+  }
+}
+
+for (const [rows, exitCode] of [[[ { uuid: "first" } ], 0], [[], 0], [null, 0], [[], 1]]) {
+  const run = session()
+  const original = run.context.worldStations
+  for (let i = 0; i < 3; i++) run.finish(rows, exitCode)
+  assert.equal(run.context.worldExpansionMisses, 3)
+  assert.equal(run.delays.length, 2)
+  assert.equal(run.context.worldStations, original)
+  run.context.openWindow("{}")
+  assert.equal(run.context.worldExpansionMisses, 0)
+  assert.equal(run.delays.at(-1), 800)
+}
+
+const run = session()
+run.finish([{ uuid: "first" }])
+run.finish([{ uuid: "first" }])
+run.finish([{ uuid: "second" }])
+assert.equal(run.context.worldExpansionMisses, 0)
+assert.equal(run.context.worldStations.length, 2)
+assert.equal(run.delays.at(-1), 1600)
+run.context.opened = false
+run.finish([{ uuid: "third" }])
+assert.equal(run.context.worldStations.length, 2)
+assert.equal(run.delays.length, 3)
+console.log("World expansion tests passed")

--- a/tests/playback.test.py
+++ b/tests/playback.test.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 from pathlib import Path
+import socket
 import subprocess
 import tempfile
 import threading
@@ -139,6 +140,31 @@ class PlaybackTest(unittest.TestCase):
         self.action("previous")
         self.wait_status(lambda s: s.get("loaded") and s["playlistPosition"] == 0)
         self.assertEqual(self.requests, failed_requests + ["/live"])
+
+    def test_status_command_does_not_overwrite_player_status(self):
+        state = dict(running=True, loaded=True, station=dict(uuid="station-0"))
+        self.status_path.write_text(json.dumps(state))
+        (self.runtime / "playlist.json").write_text('[{"uuid":"station-0"}]')
+        server = socket.socket(socket.AF_UNIX)
+        self.addCleanup(server.close)
+        server.bind(str(self.runtime / "mpv.sock"))
+        server.listen(1)
+
+        def reply():
+            connection, _ = server.accept()
+            with connection, connection.makefile("r") as requests:
+                for value in [False, "Test", 0, 1, 70, False, "auto", None]:
+                    request = json.loads(requests.readline())
+                    response = dict(request_id=request["request_id"], error="success", data=value)
+                    connection.sendall((json.dumps(response) + "\n").encode())
+
+        responder = threading.Thread(target=reply, daemon=True)
+        responder.start()
+        snapshot = self.action("status")
+        responder.join(timeout=5)
+        self.assertTrue(snapshot["loaded"])
+        self.assertEqual(snapshot["title"], "Test")
+        self.assertEqual(json.loads(self.status_path.read_text()), state)
 
 
 if __name__ == "__main__":

--- a/tests/proxy.test.py
+++ b/tests/proxy.test.py
@@ -2,11 +2,13 @@
 
 import importlib.machinery
 import importlib.util
+import contextlib
+import io
 import socket
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 sys.dont_write_bytecode = True
 project_dir = Path(__file__).resolve().parent.parent
@@ -97,8 +99,54 @@ class ProxyTests(unittest.TestCase):
 
     def test_idle_relay_returns_after_timeout(self):
         with patch.object(radio_proxy.select, "select", return_value=([], [], [])) as select_call:
-            radio_proxy.relay(object(), object())
+            self.assertEqual(radio_proxy.relay(object(), object()), "idle_timeout")
         select_call.assert_called_once()
+
+    def test_relay_identifies_which_side_closed(self):
+        client, upstream = Mock(), Mock()
+        for source, outcome in ((client, "client_closed"), (upstream, "upstream_closed")):
+            source.recv.return_value = b""
+            with patch.object(radio_proxy.select, "select", return_value=([source], [], [])):
+                self.assertEqual(radio_proxy.relay(client, upstream), outcome)
+
+    def test_connection_failure_logs_stage_without_remote_data(self):
+        output = io.StringIO()
+        request = Mock()
+        failure = radio_proxy.ProxyError(b"502 Bad Gateway")
+        failure.__cause__ = socket.gaierror(-2, "https://private.example/live?token=secret\nforged log")
+        with (
+            patch.object(radio_proxy, "diagnostic_count", 0),
+            patch.object(radio_proxy, "read_header", return_value=(b"header", b"")),
+            patch.object(radio_proxy, "parse_request", return_value=("CONNECT", "private.example", 443, b"")),
+            patch.object(radio_proxy, "connect_public", side_effect=failure),
+            contextlib.redirect_stderr(output),
+        ):
+            radio_proxy.ProxyHandler(request, None, None)
+        self.assertEqual(output.getvalue(),
+                         "radio-proxy: stage=connect outcome=rejected error=ProxyError status=502 cause=gaierror errno=-2\n")
+        request.sendall.assert_called_once_with(b"HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n")
+
+    def test_relay_exception_is_logged_and_diagnostics_are_bounded(self):
+        output = io.StringIO()
+        request = Mock()
+        upstream = Mock()
+        upstream.__enter__ = Mock(return_value=upstream)
+        upstream.__exit__ = Mock(return_value=False)
+        with (
+            patch.object(radio_proxy, "diagnostic_count", 0),
+            patch.object(radio_proxy, "read_header", return_value=(b"header", b"")),
+            patch.object(radio_proxy, "parse_request", return_value=("CONNECT", "private.example", 443, b"")),
+            patch.object(radio_proxy, "connect_public", return_value=upstream),
+            patch.object(radio_proxy, "relay", side_effect=TimeoutError("secret stream URL")),
+            contextlib.redirect_stderr(output),
+        ):
+            for _ in range(radio_proxy.MAX_DIAGNOSTICS + 2):
+                radio_proxy.ProxyHandler(request, None, None)
+        lines = output.getvalue().splitlines()
+        self.assertEqual(len(lines), radio_proxy.MAX_DIAGNOSTICS)
+        self.assertEqual(lines[0], "radio-proxy: stage=relay outcome=failed error=TimeoutError")
+        self.assertEqual(lines[-1], "radio-proxy: diagnostic limit reached for this session")
+        self.assertNotIn("secret", output.getvalue())
 
     def test_plain_http_request_is_normalized(self):
         request = (

--- a/tests/qml/tst_globe.qml
+++ b/tests/qml/tst_globe.qml
@@ -7,6 +7,7 @@ TestCase {
   when: windowShown
   width: 800
   height: 600
+  visible: true
 
   Atlas.Globe {
     id: globe
@@ -42,6 +43,13 @@ TestCase {
     globe.selectedStation = { uuid: "different", latitude: 0, longitude: 10 }
     compare(selectionChanges.count, 1)
     compare(globe.highlightedStation, null)
+  }
+
+  function test_themeChangeRepaintsWithoutInteraction() {
+    globe.backgroundColor = "#000000"
+    tryVerify(function() { return Qt.colorEqual(grabImage(globe).pixel(2, 2), "#000000") })
+    globe.backgroundColor = "#ffffff"
+    tryVerify(function() { return Qt.colorEqual(grabImage(globe).pixel(2, 2), "#ffffff") })
   }
 
   function test_offscreenMarkersAreSkippedButEdgeMarkersRemainClickable() {

--- a/tests/run
+++ b/tests/run
@@ -18,6 +18,7 @@ bash -n "$project_dir/radio-fetch" "$project_dir/radio-player" \
   "$project_dir/tests/fixtures/"*
 luac -p "$project_dir/radio-status.lua"
 node "$project_dir/tests/model.test.mjs"
+node "$project_dir/tests/expansion.test.mjs"
 python3 "$project_dir/tests/proxy.test.py"
 python3 "$project_dir/tests/playback.test.py"
 QT_QUICK_BACKEND=software /usr/lib/qt6/bin/qmltestrunner \
@@ -112,7 +113,7 @@ rg -Fq '"audio-device",$device' "$project_dir/radio-player"
 rg -Fq 'set_property","audio-device' "$project_dir/radio-player"
 rg -q 'id: outputList' "$project_dir/RadioAtlas.qml"
 sed -n '/id: stationList/,/^          }/p' "$project_dir/RadioAtlas.qml" \
-  | rg -Fq 'interactive: !root.outputMenuOpen'
+  | rg -F 'interactive: !root.outputMenuOpen' >/dev/null
 ! rg -Fq '.slice(0, 16)' "$project_dir/RadioAtlas.qml"
 sed -n '/tooltipText: root.playerOutput/,/^              }/p' "$project_dir/RadioAtlas.qml" \
   | rg -q 'focusable: true'


### PR DESCRIPTION
Theme changes could leave the globe in its old colors, background expansion kept retrying without finding new stations, and proxy failures left no useful diagnostic trail.

Repaint when palette colors change, pause expansion after three consecutive no-growth attempts until reopening, and log bounded proxy failure stages without stream URLs or credentials. Duplicate batches no longer replace the station list.

Validation also exposed a playback-status race. Live status commands now return their snapshot without overwriting the newer status file owned by mpv. Added a regression test and fixed a SIGPIPE-prone test assertion.

Validated with the full `./tests/run` suite, QML lint, plugin validation, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme color changes now update the globe immediately without requiring user interaction.
  * Background station expansion now handles unsuccessful attempts more reliably, including retries and stopping after repeated failures.
  * Checking playback status no longer overwrites the saved player status.

* **Diagnostics**
  * Proxy connection activity and failures now provide bounded diagnostic logging while protecting sensitive error details.

* **Documentation**
  * Expanded guidance for theme updates, station expansion, playback and proxy troubleshooting, connection behavior, and malformed saved state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->